### PR TITLE
feat/#9: 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/auth/controller/AuthController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/controller/AuthController.java
@@ -3,38 +3,53 @@ package com.gdg.unimatebackend.app.auth.controller;
 import com.gdg.unimatebackend.app.auth.dto.AuthTokenResponse;
 import com.gdg.unimatebackend.app.auth.dto.KakaoLoginRequest;
 import com.gdg.unimatebackend.app.auth.service.SocialAuthService;
-import com.gdg.unimatebackend.global.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @RestController
-@RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@RequestMapping("/api/auth/kakao")
 public class AuthController {
 
     private final SocialAuthService socialAuthService;
-    private final JwtUtil jwtUtil;
 
-    @Value("${app.dev-token.enabled:false}")
-    private boolean devTokenEnabled;
-
-    // ✅ 카카오 로그인 (운영에서도 사용)
-    @PostMapping("/kakao")
-    public AuthTokenResponse kakaoLogin(@RequestBody KakaoLoginRequest request) {
-        return socialAuthService.kakaoLogin(request);
+    /**
+     * 1) 카카오 로그인 페이지로 보낼 authorize URL 생성
+     * - Postman에서 호출해서 URL을 받은 뒤 브라우저로 열어도 되고
+     * - 브라우저에서 바로 /api/auth/kakao/authorize-url 을 열어도 됨
+     */
+    @GetMapping("/authorize-url")
+    public ResponseEntity<String> authorizeUrl() {
+        return ResponseEntity.ok(socialAuthService.buildKakaoAuthorizeUrl());
     }
 
-    // ⚠️ 개발용 토큰 발급 (운영에서는 app.dev-token.enabled=false로 막힘)
-    @GetMapping("/dev-token")
-    public Map<String, Object> devToken(@RequestParam Long userId) {
-        if (!devTokenEnabled) {
-            // 운영에서 404처럼 보이게 하고 싶으면 IllegalArgumentException 대신 RuntimeException으로 커스텀 처리도 가능
-            throw new IllegalArgumentException("dev-token is disabled");
-        }
-        String token = jwtUtil.generateToken(userId);
-        return Map.of("token", token, "userId", userId);
+    /**
+     * 2) 카카오 로그인 후 리다이렉트되는 콜백
+     * - redirect-uri로 등록한 주소가 여기와 정확히 같아야 함
+     * - code -> token -> user/me -> 우리 서비스 JWT 발급
+     */
+    @GetMapping("/callback")
+    public ResponseEntity<AuthTokenResponse> callback(@RequestParam("code") String code) {
+        return ResponseEntity.ok(socialAuthService.kakaoLoginByCode(code));
+    }
+
+    /**
+     * 3) (백엔드 단독 테스트용) access_token을 직접 넣어서 로그인 처리
+     * - 프론트 없이 Postman으로 가장 쉽게 검증 가능
+     */
+    @PostMapping("/login")
+    public ResponseEntity<AuthTokenResponse> login(@RequestBody KakaoLoginRequest request) {
+        return ResponseEntity.ok(socialAuthService.kakaoLogin(request));
+    }
+
+    /**
+     * ✅ (테스트 전용) 카카오 인가코드(code)만 화면에 출력
+     * - 이 엔드포인트는 code를 "소비하지 않는다"
+     * - Postman에서 /callback 호출할 때 code를 1회만 사용하게 해준다.
+     */
+    @GetMapping("/code")
+    public ResponseEntity<String> codeOnly(@RequestParam("code") String code) {
+        return ResponseEntity.ok(code);
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/app/auth/dto/AuthTokenResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/dto/AuthTokenResponse.java
@@ -1,15 +1,11 @@
 package com.gdg.unimatebackend.app.auth.dto;
 
-import com.gdg.unimatebackend.app.user.entity.AuthProvider;
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder
-public class AuthTokenResponse {
-    private String token;
-    private Long userId;
-    private AuthProvider provider;
-    private String email;
-    private String nickname;
-}
+public record AuthTokenResponse(
+        String accessToken,
+        String refreshToken,
+        Long userId,
+        String provider,
+        String providerId,
+        String nickname,
+        String profileImageUrl
+) {}

--- a/src/main/java/com/gdg/unimatebackend/app/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/dto/KakaoLoginRequest.java
@@ -1,15 +1,5 @@
 package com.gdg.unimatebackend.app.auth.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class KakaoLoginRequest {
-    // 둘 중 하나만 오면 됨
-    private String code;        // Authorization Code 방식
-    private String accessToken; // 프론트가 직접 받은 토큰 방식
-
-    // code 방식일 때 redirectUri를 요청에서 받는 옵션 (없으면 yml 값 사용)
-    private String redirectUri;
-}
+public record KakaoLoginRequest(
+        String accessToken
+) {}

--- a/src/main/java/com/gdg/unimatebackend/app/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,12 @@
+package com.gdg.unimatebackend.app.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") Integer expiresIn,
+        @JsonProperty("refresh_token_expires_in") Integer refreshTokenExpiresIn,
+        @JsonProperty("scope") String scope
+) {}

--- a/src/main/java/com/gdg/unimatebackend/app/auth/dto/KakaoUserResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/dto/KakaoUserResponse.java
@@ -1,0 +1,63 @@
+package com.gdg.unimatebackend.app.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserResponse(
+        Long id,
+        @JsonProperty("connected_at") String connectedAt,
+        KakaoProperties properties,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public String nickname() {
+        if (properties != null && properties.nickname != null) return properties.nickname;
+        if (kakaoAccount != null && kakaoAccount.profile != null && kakaoAccount.profile.nickname != null) return kakaoAccount.profile.nickname;
+        return "카카오사용자";
+    }
+
+    public String profileImageUrl() {
+        if (properties != null && properties.profileImage != null) return properties.profileImage;
+        if (kakaoAccount != null && kakaoAccount.profile != null && kakaoAccount.profile.profileImageUrl != null) return kakaoAccount.profile.profileImageUrl;
+        return null;
+    }
+
+    public String email() {
+        if (kakaoAccount != null) return kakaoAccount.email;
+        return null;
+    }
+
+    public static class KakaoProperties {
+        public String nickname;
+
+        @JsonProperty("profile_image")
+        public String profileImage;
+
+        @JsonProperty("thumbnail_image")
+        public String thumbnailImage;
+    }
+
+    public static class KakaoAccount {
+        public String email;
+
+        @JsonProperty("profile")
+        public KakaoProfile profile;
+
+        @JsonProperty("profile_nickname_needs_agreement")
+        public Boolean profileNicknameNeedsAgreement;
+
+        @JsonProperty("profile_image_needs_agreement")
+        public Boolean profileImageNeedsAgreement;
+    }
+
+    public static class KakaoProfile {
+        public String nickname;
+
+        @JsonProperty("profile_image_url")
+        public String profileImageUrl;
+
+        @JsonProperty("thumbnail_image_url")
+        public String thumbnailImageUrl;
+
+        @JsonProperty("is_default_image")
+        public Boolean isDefaultImage;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/auth/service/KakaoApiService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/service/KakaoApiService.java
@@ -1,0 +1,65 @@
+package com.gdg.unimatebackend.app.auth.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gdg.unimatebackend.app.auth.dto.KakaoUserResponse;
+import com.gdg.unimatebackend.global.exception.KakaoApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KakaoApiService implements InitializingBean {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${oauth.kakao.user-info-uri:https://kapi.kakao.com/v2/user/me}")
+    private String userInfoUri;
+
+    @Override
+    public void afterPropertiesSet() {
+        log.info("Kakao user-info-uri = {}", userInfoUri);
+    }
+
+    public KakaoUserResponse getUserInfo(String accessToken) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + accessToken);
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            // ✅ 요청할 속성을 명시 (동의항목이 켜져 있으면 내려옴)
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("property_keys", "[\"properties.nickname\",\"properties.profile_image\",\"kakao_account.profile\",\"kakao_account.email\"]");
+
+            HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
+
+            ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
+                    userInfoUri,
+                    HttpMethod.POST,
+                    entity,
+                    KakaoUserResponse.class
+            );
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return response.getBody();
+            }
+            throw new KakaoApiException("카카오 사용자 정보 조회 실패");
+        } catch (HttpClientErrorException.Unauthorized e) {
+            throw new KakaoApiException("유효하지 않은 카카오 액세스 토큰", e, 401);
+        } catch (HttpClientErrorException.Forbidden e) {
+            throw new KakaoApiException("카카오 API 권한 오류(403). 플랫폼/카카오로그인 활성화/도메인 설정 확인", e, 403);
+        } catch (HttpClientErrorException e) {
+            throw new KakaoApiException("카카오 API 오류: " + e.getStatusCode(), e, e.getStatusCode().value());
+        } catch (Exception e) {
+            throw new KakaoApiException("카카오 사용자 정보 조회 중 오류", e);
+        }
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/auth/service/KakaoOAuthClient.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/service/KakaoOAuthClient.java
@@ -1,120 +1,116 @@
 package com.gdg.unimatebackend.app.auth.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
+import com.gdg.unimatebackend.app.auth.dto.KakaoTokenResponse;
+import com.gdg.unimatebackend.global.exception.KakaoApiException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
-@Component
+@Service
+@Slf4j
 @RequiredArgsConstructor
 public class KakaoOAuthClient {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private final WebClient webClient = WebClient.builder().build();
+    // ✅ RestTemplate을 new로 만들지 말고, Spring Bean 주입받는 방식이 가장 안전
+    private final RestTemplate restTemplate;
 
-    @Value("${oauth.kakao.client-id:}")
+    @Value("${oauth.kakao.client-id}")
     private String clientId;
 
-    @Value("${oauth.kakao.client-secret:}")
+    /**
+     * ✅ 네 앱 상태상 client_secret이 사실상 필수.
+     * 값이 비어있으면 바로 실패하게 해서, 401을 환경설정 문제로 빠르게 분리한다.
+     */
+    @Value("${oauth.kakao.client-secret}")
     private String clientSecret;
 
-    @Value("${oauth.kakao.redirect-uri:}")
-    private String defaultRedirectUri;
+    @Value("${oauth.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${oauth.kakao.authorize-uri:https://kauth.kakao.com/oauth/authorize}")
+    private String authorizeUri;
 
     @Value("${oauth.kakao.token-uri:https://kauth.kakao.com/oauth/token}")
     private String tokenUri;
 
-    @Value("${oauth.kakao.user-info-uri:https://kapi.kakao.com/v2/user/me}")
-    private String userInfoUri;
+    public String buildAuthorizeUrl() {
+        return UriComponentsBuilder.fromUriString(authorizeUri)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .build(true) // ✅ 인코딩 관련 이슈 줄이기
+                .toUriString();
+    }
 
-    public String exchangeCodeToAccessToken(String code, String redirectUri) {
-        String ru = (redirectUri != null && !redirectUri.isBlank()) ? redirectUri : defaultRedirectUri;
+    public KakaoTokenResponse exchangeCodeToToken(String code) {
+        validateConfig();
+        if (code == null || code.isBlank()) {
+            throw new KakaoApiException("인가 코드(code)가 비어있습니다.");
+        }
 
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("grant_type", "authorization_code");
+            body.add("client_id", clientId);
+            body.add("redirect_uri", redirectUri);
+            body.add("code", code);
+            body.add("client_secret", clientSecret); // ✅ 필수로 항상 포함
+
+            HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
+
+            // ✅ 민감정보 마스킹 로그 (client_secret 전체 노출 금지)
+            log.info("[KakaoToken] endpoint={}", tokenUri);
+            log.info("[KakaoToken] client_id={}, redirect_uri={}", mask(clientId, 6), redirectUri);
+            log.info("[KakaoToken] code={}", mask(code, 8));
+            log.info("[KakaoToken] client_secret_present={}", !clientSecret.isBlank());
+
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                    tokenUri,
+                    HttpMethod.POST,
+                    entity,
+                    KakaoTokenResponse.class
+            );
+
+            KakaoTokenResponse token = response.getBody();
+            if (response.getStatusCode().is2xxSuccessful() && token != null && token.accessToken() != null) {
+                return token;
+            }
+
+            throw new KakaoApiException("카카오 토큰 발급 실패: empty body or missing access_token");
+        } catch (HttpClientErrorException e) {
+            String respBody = e.getResponseBodyAsString();
+            log.error("[KakaoToken] fail status={}, body={}", e.getStatusCode(), (respBody == null || respBody.isBlank()) ? "<empty>" : respBody);
+            throw new KakaoApiException("카카오 토큰 발급 실패: " + e.getStatusCode(), e, e.getStatusCode().value());
+        } catch (Exception e) {
+            throw new KakaoApiException("카카오 토큰 발급 중 오류", e);
+        }
+    }
+
+    private void validateConfig() {
         if (clientId == null || clientId.isBlank()) {
-            throw new IllegalArgumentException("KAKAO_CLIENT_ID is required.");
+            throw new KakaoApiException("oauth.kakao.client-id 설정이 비어있습니다.");
         }
-        if (ru == null || ru.isBlank()) {
-            throw new IllegalArgumentException("KAKAO_REDIRECT_URI is required for code login.");
+        if (redirectUri == null || redirectUri.isBlank()) {
+            throw new KakaoApiException("oauth.kakao.redirect-uri 설정이 비어있습니다.");
         }
-
-        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-        form.add("grant_type", "authorization_code");
-        form.add("client_id", clientId);
-        form.add("redirect_uri", ru);
-        form.add("code", code);
-
-        if (clientSecret != null && !clientSecret.isBlank()) {
-            form.add("client_secret", clientSecret);
-        }
-
-        String body = webClient.post()
-                .uri(tokenUri)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .accept(MediaType.APPLICATION_JSON)
-                .body(BodyInserters.fromFormData(form))
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
-
-        try {
-            JsonNode node = objectMapper.readTree(body);
-            JsonNode accessToken = node.get("access_token");
-            if (accessToken == null) throw new IllegalArgumentException("Kakao token response missing access_token.");
-            return accessToken.asText();
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to parse kakao token response.");
+        if (clientSecret == null || clientSecret.isBlank()) {
+            throw new KakaoApiException("oauth.kakao.client-secret 설정이 비어있습니다. (현재 앱은 client_secret 필수)");
         }
     }
 
-    public KakaoUserInfo fetchUserInfo(String accessToken) {
-        String body = webClient.get()
-                .uri(userInfoUri)
-                .accept(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
-
-        try {
-            JsonNode root = objectMapper.readTree(body);
-
-            String id = root.get("id").asText();
-
-            JsonNode kakaoAccount = root.get("kakao_account");
-            String email = null;
-            if (kakaoAccount != null && kakaoAccount.get("email") != null) {
-                email = kakaoAccount.get("email").asText();
-            }
-
-            String nickname = null;
-            JsonNode profile = (kakaoAccount != null) ? kakaoAccount.get("profile") : null;
-            if (profile != null && profile.get("nickname") != null) {
-                nickname = profile.get("nickname").asText();
-            }
-
-            return new KakaoUserInfo(id, email, nickname);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to parse kakao user info.");
-        }
-    }
-
-    @Getter
-    public static class KakaoUserInfo {
-        private final String providerId;
-        private final String email;
-        private final String nickname;
-
-        public KakaoUserInfo(String providerId, String email, String nickname) {
-            this.providerId = providerId;
-            this.email = email;
-            this.nickname = nickname;
-        }
+    private String mask(String value, int keepPrefix) {
+        if (value == null) return "null";
+        if (value.length() <= keepPrefix) return value;
+        return value.substring(0, keepPrefix) + "****";
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/app/auth/service/SocialAuthService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/service/SocialAuthService.java
@@ -2,6 +2,10 @@ package com.gdg.unimatebackend.app.auth.service;
 
 import com.gdg.unimatebackend.app.auth.dto.AuthTokenResponse;
 import com.gdg.unimatebackend.app.auth.dto.KakaoLoginRequest;
+import com.gdg.unimatebackend.app.auth.dto.KakaoTokenResponse;
+import com.gdg.unimatebackend.app.auth.dto.KakaoUserResponse;
+import com.gdg.unimatebackend.app.auth.service.KakaoApiService;
+import com.gdg.unimatebackend.app.auth.service.KakaoOAuthClient;
 import com.gdg.unimatebackend.app.user.entity.AuthProvider;
 import com.gdg.unimatebackend.app.user.entity.User;
 import com.gdg.unimatebackend.app.user.repository.UserRepository;
@@ -15,57 +19,68 @@ import org.springframework.transaction.annotation.Transactional;
 public class SocialAuthService {
 
     private final KakaoOAuthClient kakaoOAuthClient;
+    private final KakaoApiService kakaoApiService;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
 
-    @Transactional
-    public AuthTokenResponse kakaoLogin(KakaoLoginRequest request) {
-        String accessToken = resolveAccessToken(request);
-
-        KakaoOAuthClient.KakaoUserInfo info = kakaoOAuthClient.fetchUserInfo(accessToken);
-
-        // A안 전제: email은 필수 (미동의면 가입 불가 정책으로 처리)
-        if (info.getEmail() == null || info.getEmail().isBlank()) {
-            throw new IllegalArgumentException("Kakao email consent is required.");
-        }
-
-        // 1) 이메일로 계정 찾기 (Travodo 전제)
-        User user = userRepository.findByEmail(info.getEmail())
-                .orElseGet(() -> userRepository.save(
-                        User.builder()
-                                .email(info.getEmail())
-                                .nickname(info.getNickname())
-                                .provider(AuthProvider.KAKAO)
-                                .providerId(info.getProviderId())
-                                .build()
-                ));
-
-        // 2) 기존 계정이면 소셜 연결(또는 갱신)
-        //    이미 다른 provider로 연결되어 있더라도 정책상 여기서 덮어쓸지/거부할지 선택 가능
-        user.linkSocial(AuthProvider.KAKAO, info.getProviderId());
-
-        // 3) 닉네임 업데이트(널이면 유지)
-        user.updateProfile(info.getNickname());
-
-        // 4) JWT 발급
-        String token = jwtUtil.generateToken(user.getId());
-
-        return AuthTokenResponse.builder()
-                .token(token)
-                .userId(user.getId())
-                .provider(user.getProvider())
-                .email(user.getEmail())
-                .nickname(user.getNickname())
-                .build();
+    public String buildKakaoAuthorizeUrl() {
+        return kakaoOAuthClient.buildAuthorizeUrl();
     }
 
-    private String resolveAccessToken(KakaoLoginRequest request) {
-        if (request.getAccessToken() != null && !request.getAccessToken().isBlank()) {
-            return request.getAccessToken();
+    @Transactional
+    public AuthTokenResponse kakaoLogin(KakaoLoginRequest request) {
+        String accessToken = request.accessToken();
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalArgumentException("accessToken is required.");
         }
-        if (request.getCode() != null && !request.getCode().isBlank()) {
-            return kakaoOAuthClient.exchangeCodeToAccessToken(request.getCode(), request.getRedirectUri());
+
+        KakaoUserResponse me = kakaoApiService.getUserInfo(accessToken.trim());
+        return upsertAndIssueJwt(me);
+    }
+
+    @Transactional
+    public AuthTokenResponse kakaoLoginByCode(String code) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("code is required.");
         }
-        throw new IllegalArgumentException("Either accessToken or code must be provided.");
+
+        KakaoTokenResponse token = kakaoOAuthClient.exchangeCodeToToken(code.trim());
+        KakaoUserResponse me = kakaoApiService.getUserInfo(token.accessToken());
+        return upsertAndIssueJwt(me);
+    }
+
+    private AuthTokenResponse upsertAndIssueJwt(KakaoUserResponse me) {
+        if (me == null || me.id() == null) {
+            throw new IllegalArgumentException("Kakao user id is required.");
+        }
+
+        String providerId = String.valueOf(me.id());
+
+        // ✅ 재할당 없는 값으로 고정 (람다 캡처 OK)
+        final String finalEmail =
+                (me.email() != null && !me.email().isBlank())
+                        ? me.email()
+                        : providerId + "@unimate.local";
+
+        User user = userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, providerId)
+                .orElseGet(() -> User.createKakaoUser(providerId, finalEmail, me.nickname()));
+
+        // 기존 유저도 닉네임 최신화(선택)
+        user.updateProfile(me.nickname());
+
+        User saved = userRepository.save(user);
+
+        String accessToken = jwtUtil.generateToken(saved.getId());
+        String refreshToken = jwtUtil.generateToken(saved.getId()); // 임시 동일
+
+        return new AuthTokenResponse(
+                accessToken,
+                refreshToken,
+                saved.getId(),
+                String.valueOf(saved.getProvider()),
+                saved.getProviderId(),
+                saved.getNickname(),
+                null
+        );
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/app/user/controller/UserController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.gdg.unimatebackend.app.user.controller;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,10 +12,38 @@ public class UserController {
 
     @GetMapping("/api/me")
     public Map<String, Object> me(Authentication authentication) {
-        Long userId = (Long) authentication.getPrincipal();
+        // Authentication이 null이면 (보안 설정상) 보통 여기까지 오기 전에 401이지만,
+        // 혹시라도 들어오면 500 대신 안전하게 응답
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Map.of(
+                    "authenticated", false,
+                    "userId", null,
+                    "principalType", null,
+                    "principal", null
+            );
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        Long userId = null;
+
+        // ✅ principal을 Long으로 못 박지 말고 타입별로 안전 처리
+        if (principal instanceof Long l) {
+            userId = l;
+        } else if (principal instanceof String s) {
+            // 예: "1" 같은 문자열로 들어오는 경우 대비
+            try {
+                userId = Long.parseLong(s);
+            } catch (NumberFormatException ignored) {
+                // "anonymousUser" 같은 값이면 userId는 null 유지
+            }
+        }
+
         return Map.of(
                 "authenticated", true,
-                "userId", userId
+                "userId", userId,
+                "principalType", principal == null ? null : principal.getClass().getName(),
+                "principal", String.valueOf(principal)
         );
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/app/user/entity/User.java
+++ b/src/main/java/com/gdg/unimatebackend/app/user/entity/User.java
@@ -1,6 +1,5 @@
 package com.gdg.unimatebackend.app.user.entity;
 
-import com.gdg.unimatebackend.app.user.entity.AuthProvider;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -10,8 +9,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -80,4 +77,14 @@ public class User {
         this.provider = provider;
         this.providerId = providerId;
     }
+    public static User createKakaoUser(String providerId, String email, String nickname) {
+        User u = new User(); // ✅ 같은 클래스 내부라 protected 생성자여도 OK
+
+        u.linkSocial(AuthProvider.KAKAO, providerId); // 너가 이미 쓰는 메서드
+        u.email = email; // ✅ setEmail 없으니 필드 직접 세팅(클래스 내부니까 가능)
+
+        u.updateProfile(nickname); // 너가 이미 쓰는 메서드
+        return u;
+    }
+
 }

--- a/src/main/java/com/gdg/unimatebackend/config/RestTemplateConfig.java
+++ b/src/main/java/com/gdg/unimatebackend/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.gdg.unimatebackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/unimatebackend/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/health/**").permitAll()
+                        .requestMatchers("/api/system/**").permitAll()
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/gdg/unimatebackend/global/exception/KakaoApiException.java
+++ b/src/main/java/com/gdg/unimatebackend/global/exception/KakaoApiException.java
@@ -1,0 +1,34 @@
+package com.gdg.unimatebackend.global.exception;
+
+/**
+ * 카카오 API 호출 중 발생하는 예외
+ */
+public class KakaoApiException extends RuntimeException {
+
+    private final int httpStatus;
+
+    public KakaoApiException(String message) {
+        super(message);
+        this.httpStatus = 500;
+    }
+
+    public KakaoApiException(String message, int httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public KakaoApiException(String message, Throwable cause, int httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public KakaoApiException(String message, Throwable cause) {
+        super(message, cause);
+        this.httpStatus = 500;
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,10 @@
+server:
+  port: ${SERVER_PORT:8080}
+
 spring:
+  profiles:
+    active: prod
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
@@ -13,12 +19,16 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      ddl-auto: update   # ✅ 운영은 절대 create 금지
     properties:
       hibernate:
         format_sql: false
     show-sql: false
     open-in-view: false
+
+  jackson:
+    date-format: yyyy-MM-dd
+    time-zone: Asia/Seoul
 
   mail:
     host: smtp.gmail.com
@@ -40,10 +50,10 @@ springdoc:
   api-docs:
     path: /v3/api-docs
   swagger-ui:
+    # ✅ 운영에서는 swagger 접근 제한/차단 권장
+    enabled: ${SWAGGER_ENABLED:false}
     path: /swagger-ui.html
     url: /v3/api-docs
-    display-request-duration: true
-    groups-order: ASC
 
 jwt:
   secret: ${JWT_SECRET}
@@ -51,12 +61,22 @@ jwt:
 
 aws:
   s3:
-    access-key: ${AWS_ACCESS_KEY:${AWS_ACCESS_KEY_ID:}}
-    secret-key: ${AWS_SECRET_KEY:${AWS_SECRET_ACCESS_KEY:}}
-    bucket-name: ${AWS_S3_BUCKET_NAME:${S3_BUCKETNAME:}}
-    base-url: ${AWS_S3_BASE_URL:}
-    region: ${AWS_S3_REGION:${S3_REGION:ap-northeast-2}}
+    access-key: ${AWS_ACCESS_KEY_ID}
+    secret-key: ${AWS_SECRET_ACCESS_KEY}
+    bucket-name: ${AWS_S3_BUCKET_NAME}
+    base-url: ${AWS_S3_BASE_URL}
+    region: ${AWS_S3_REGION:ap-northeast-2}
 
 app:
   swagger:
-    prod-url: http://seok-hwan1.duckdns.org
+    prod-url: https://seok-hwan1.duckdns.org
+  dev-token:
+    enabled: false
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: https://seok-hwan1.duckdns.org/api/auth/kakao/callback
+    authorize-uri: https://kauth.kakao.com/oauth/authorize
+    token-uri: https://kauth.kakao.com/oauth/token

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,16 +7,19 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:unimate_db}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:unimate_db}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:1234}
     hikari:
-      maximum-pool-size: 5
-      minimum-idle: 2
-      connection-timeout: 30000
+      maximum-pool-size: ${DB_POOL_MAX:5}
+      minimum-idle: ${DB_POOL_MIN_IDLE:2}
+      connection-timeout: ${DB_CONN_TIMEOUT:30000}
+      idle-timeout: ${DB_IDLE_TIMEOUT:600000}
+      max-lifetime: ${DB_MAX_LIFETIME:1800000}
 
   jpa:
     hibernate:
+      # 로컬 테스트면 create / 운영이면 update 권장
       ddl-auto: ${DDL_AUTO:create}
     properties:
       hibernate:
@@ -66,24 +69,23 @@ jwt:
 
 aws:
   s3:
-    access-key: ${AWS_ACCESS_KEY:}
-    secret-key: ${AWS_SECRET_KEY:}
-    bucket-name: ${AWS_S3_BUCKET_NAME:}
+    access-key: ${AWS_ACCESS_KEY:${AWS_ACCESS_KEY_ID:}}
+    secret-key: ${AWS_SECRET_KEY:${AWS_SECRET_ACCESS_KEY:}}
+    bucket-name: ${AWS_S3_BUCKET_NAME:${S3_BUCKETNAME:}}
     base-url: ${AWS_S3_BASE_URL:}
-    region: ${AWS_S3_REGION:ap-northeast-2}
+    region: ${AWS_S3_REGION:${S3_REGION:ap-northeast-2}}
 
 app:
   swagger:
-    prod-url: http://localhost:8080
+    prod-url: ${SWAGGER_PROD_URL:http://localhost:8080}
   dev-token:
     enabled: ${DEV_TOKEN_ENABLED:false}
 
 oauth:
   kakao:
-    client-id: ${KAKAO_CLIENT_ID:}
-    client-secret: ${KAKAO_CLIENT_SECRET:} # 없어도 되는 경우 많음(카카오 설정에 따라)
-    redirect-uri: ${KAKAO_REDIRECT_URI:}   # code 방식 쓸 때 필요
+    client-id: ${KAKAO_CLIENT_ID:f0090451b3aedc13683fc670394f8de8}
+    client-secret: ${KAKAO_CLIENT_SECRET:R9E7xGESxXIk9Q8HVfh2nu8adIUsOpaA}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/auth/kakao/callback}
+    authorize-uri: https://kauth.kakao.com/oauth/authorize
     token-uri: https://kauth.kakao.com/oauth/token
-    user-info-uri: https://kapi.kakao.com/v2/user/me
-# 프론트가 “access token을 직접 넘겨주는 방식”이면 redirect-uri 없어도 됨.
-# 프론트가 “Authorization Code 방식”이면 redirect-uri가 반드시 필요.
+


### PR DESCRIPTION
# 카카오 로그인(OAuth 2.0) 구현 정리

## 개요
Unimate Backend 프로젝트에 **카카오 OAuth 2.0 기반 로그인 기능**을 구현하였다.  
인가 코드 발급부터 사용자 정보 조회, 내부 사용자 저장 및 JWT 발급까지의 전체 인증 흐름을 백엔드 단에서 완성하였다.

---

## 구현 목표
- 카카오 OAuth 2.0 Authorization Code Flow 적용
- 프론트엔드 없이 **백엔드 단독으로 로그인 검증 가능**
- 에러 없이 안정적인 로그인 플로우 구성

---

## 전체 로그인 흐름

1. **카카오 로그인 페이지 URL 생성**
2. 사용자가 카카오 로그인 진행
3. 카카오 → 우리 서버로 `authorization code` 리다이렉트
4. 서버에서 code로 카카오 access token 발급
5. access token으로 카카오 사용자 정보 조회
6. 사용자 upsert (신규 생성 또는 기존 사용자 갱신)
7. JWT(access / refresh) 발급 후 응답

---

## API 엔드포인트 정리

### 1️⃣ 카카오 로그인 URL 생성
```http
GET /api/auth/kakao/authorize-url
