### PR TITLE
feat/#9: 이메일 전송 메세지 수정 및 로컬 운영 단계 분리

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/auth/service/EmailService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/service/EmailService.java
@@ -30,10 +30,10 @@ public class EmailService {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(email);
         message.setFrom(from); // 발신자 주소 미설정 시 "can't determine local email address" 오류 발생
-        message.setSubject("[Travodo] 이메일 인증 코드");
+        message.setSubject("[Unimate] 이메일 인증 코드");
         message.setText(
                 "안녕하세요.\n\n" +
-                        "Travodo 이메일 인증 코드입니다.\n\n" +
+                        "Unimate 이메일 인증 코드입니다.\n\n" +
                         "인증 코드: " + code + "\n\n" +
                         "이 코드는 10분간 유효합니다.\n\n" +
                         "본인이 요청한 것이 아니라면 이 메일을 무시하세요."

--- a/src/main/java/com/gdg/unimatebackend/app/auth/service/SocialAuthService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/service/SocialAuthService.java
@@ -59,7 +59,7 @@ public class SocialAuthService {
             log.info("카카오 로그인 - 기존 사용자: {}", user.getEmail());
         } else {
             // 이메일로 이미 가입된 사용자가 있는지 확인 (계정 통합)
-            if (email != null && !email.isEmpty() && !email.contains("@travodo.local")) {
+            if (email != null && !email.isEmpty() && !email.contains("@Unimate.local")) {
                 Optional<User> emailUserOpt = userRepository.findByEmail(email);
                 if (emailUserOpt.isPresent()) {
                     User emailUser = emailUserOpt.get();
@@ -153,7 +153,7 @@ public class SocialAuthService {
      * @return 대체 이메일 주소
      */
     private String generateAlternativeEmail(AuthProvider provider, String providerId) {
-        return provider.name().toLowerCase() + "_" + providerId + "@travodo.local";
+        return provider.name().toLowerCase() + "_" + providerId + "@Unimate.local";
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      ddl-auto: ${DDL_AUTO:create-drop}
     properties:
       hibernate:
         format_sql: false


### PR DESCRIPTION
로그인할때 이메일 전송 메세지 통일했고 포스트맨에서 실행할때는(로컬) 항상 초기화 된 상태에서 할 수 있게 고쳤습니다