### PR TITLE
feat/#9: 카카오 네이버 로그인 방식 통일

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/auth/controller/AuthController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/controller/AuthController.java
@@ -2,8 +2,10 @@ package com.gdg.unimatebackend.app.auth.controller;
 
 import com.gdg.unimatebackend.app.auth.dto.*;
 import com.gdg.unimatebackend.app.auth.service.AuthService;
+import com.gdg.unimatebackend.app.auth.service.KakaoApiService;
 import com.gdg.unimatebackend.app.auth.service.NaverApiService;
 import com.gdg.unimatebackend.app.auth.service.SocialAuthService;
+import com.gdg.unimatebackend.app.user.entity.AuthProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -28,6 +30,7 @@ public class AuthController {
     private final AuthService authService;
     private final SocialAuthService socialAuthService;
     private final NaverApiService naverApiService;
+    private final KakaoApiService kakaoApiService;
 
     @Value("${oauth.naver.client-id}")
     private String naverClientId;
@@ -38,6 +41,15 @@ public class AuthController {
     @Value("${oauth.naver.authorize-uri}")
     private String naverAuthorizeUri;
 
+    // ===== KAKAO =====
+    @Value("${oauth.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${oauth.kakao.authorize-uri}")
+    private String kakaoAuthorizeUri;
 
     @PostMapping("/email/verification/send")
     @Operation(summary = "이메일 인증번호 전송", description = "이메일로 인증번호를 전송합니다")
@@ -124,7 +136,7 @@ public class AuthController {
     }
 
     @PostMapping("/social/login")
-    @Operation(summary = "소셜 로그인", description = "카카오 로그인을 처리합니다")
+    @Operation(summary = "소셜 로그인", description = "accessToken 기반 소셜 로그인을 처리합니다")
     public ResponseEntity<AuthResponse> socialLogin(@Valid @RequestBody SocialLoginRequest request) {
         AuthResponse response = socialAuthService.socialLogin(
                 request.getProvider(),
@@ -138,8 +150,6 @@ public class AuthController {
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "현재 로그인한 사용자를 로그아웃합니다")
     public ResponseEntity<Map<String, String>> logout(Authentication authentication) {
-        // JWT는 stateless이므로 클라이언트에서 토큰을 삭제하면 됩니다.
-        // 필요시 토큰 블랙리스트 기능을 추가할 수 있습니다.
         Map<String, String> response = new HashMap<>();
         response.put("message", "로그아웃되었습니다");
         return ResponseEntity.ok(response);
@@ -169,16 +179,57 @@ public class AuthController {
     ) {
         var tokenRes = naverApiService.exchangeCodeToToken(code, state, naverRedirectUri);
         if (tokenRes == null || tokenRes.accessToken() == null) {
-            throw new IllegalArgumentException("네이버 토큰 교환 실패: " + (tokenRes == null ? "null" : tokenRes.errorDescription()));
+            throw new IllegalArgumentException("네이버 토큰 교환 실패: " +
+                    (tokenRes == null ? "null" : tokenRes.errorDescription()));
         }
 
         AuthResponse response = socialAuthService.socialLogin(
-                com.gdg.unimatebackend.app.user.entity.AuthProvider.NAVER,
+                AuthProvider.NAVER,
                 tokenRes.accessToken(),
                 null,
                 null
         );
         return ResponseEntity.ok(response);
     }
-}
 
+    @GetMapping("/kakao/authorize-url")
+    public ResponseEntity<Map<String, String>> kakaoAuthorizeUrl() {
+        String state = UUID.randomUUID().toString();
+
+        String url = UriComponentsBuilder
+                .fromUriString(kakaoAuthorizeUri)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", kakaoClientId)
+                .queryParam("redirect_uri", kakaoRedirectUri)
+                .queryParam("state", state)
+                .toUriString();
+
+        Map<String, String> res = new HashMap<>();
+        res.put("authorizeUrl", url);
+        res.put("state", state);
+        return ResponseEntity.ok(res);
+    }
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<AuthResponse> kakaoCallback(
+            @RequestParam String code,
+            @RequestParam(required = false) String state
+    ) {
+        // 1) code -> kakao access_token
+        KakaoApiService.KakaoTokenResponse tokenRes = kakaoApiService.exchangeCodeToToken(code, kakaoRedirectUri);
+
+        if (tokenRes == null || tokenRes.getAccessToken() == null || tokenRes.getAccessToken().isBlank()) {
+            String reason = (tokenRes == null) ? "null" : (tokenRes.getErrorDescription() != null ? tokenRes.getErrorDescription() : tokenRes.getError());
+            throw new IllegalArgumentException("카카오 토큰 교환 실패: " + reason);
+        }
+
+        // 2) kakao access_token -> 우리 JWT 발급
+        AuthResponse response = socialAuthService.socialLogin(
+                AuthProvider.KAKAO,
+                tokenRes.getAccessToken(),
+                null,
+                null
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/auth/service/KakaoApiService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/auth/service/KakaoApiService.java
@@ -7,11 +7,10 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -26,8 +25,17 @@ public class KakaoApiService implements InitializingBean {
     private final RestTemplate restTemplate;
     private final String kakaoApiBaseUrl = "https://kapi.kakao.com";
 
+    // 카카오 OAuth 토큰 교환 엔드포인트
+    @Value("${oauth.kakao.token-uri:https://kauth.kakao.com/oauth/token}")
+    private String tokenUri;
+
+    // 카카오 REST API Key (client_id)
     @Value("${oauth.kakao.client-id:}")
     private String restApiKey;
+
+    // 카카오 앱 설정에 따라 필요할 수도/없을 수도 있어 optional 처리
+    @Value("${oauth.kakao.client-secret:}")
+    private String clientSecret;
 
     public KakaoApiService() {
         this.restTemplate = new RestTemplate();
@@ -39,6 +47,84 @@ public class KakaoApiService implements InitializingBean {
             log.warn("카카오 REST API 키가 설정되지 않았습니다. 카카오 로그인이 작동하지 않을 수 있습니다.");
         } else {
             log.info("카카오 REST API 키가 설정되었습니다. (키: {}...)", restApiKey.substring(0, Math.min(8, restApiKey.length())));
+        }
+    }
+
+    // =========================
+    // code -> access_token 교환
+    // =========================
+
+    @Getter
+    @Setter
+    public static class KakaoTokenResponse {
+        @JsonProperty("access_token")
+        private String accessToken;
+
+        @JsonProperty("token_type")
+        private String tokenType;
+
+        @JsonProperty("refresh_token")
+        private String refreshToken;
+
+        @JsonProperty("expires_in")
+        private Integer expiresIn;
+
+        @JsonProperty("scope")
+        private String scope;
+
+        @JsonProperty("error")
+        private String error;
+
+        @JsonProperty("error_description")
+        private String errorDescription;
+    }
+
+    /**
+     * 인가 코드(code)를 카카오 access_token으로 교환
+     */
+    public KakaoTokenResponse exchangeCodeToToken(String code, String redirectUri) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("grant_type", "authorization_code");
+            body.add("client_id", restApiKey);
+            body.add("redirect_uri", redirectUri);
+            body.add("code", code);
+
+            // client_secret을 쓰는 앱이면 추가
+            if (clientSecret != null && !clientSecret.isBlank()) {
+                body.add("client_secret", clientSecret);
+            }
+
+            HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
+
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                    tokenUri,
+                    HttpMethod.POST,
+                    entity,
+                    KakaoTokenResponse.class
+            );
+
+            KakaoTokenResponse res = response.getBody();
+            if (response.getStatusCode().is2xxSuccessful() && res != null && res.getAccessToken() != null) {
+                return res;
+            }
+
+            throw new KakaoApiException("카카오 토큰 교환 실패", null,
+                    response.getStatusCode().value());
+        } catch (HttpClientErrorException e) {
+            log.error("카카오 토큰 교환 HTTP 오류 ({}): {}", e.getStatusCode(), e.getMessage());
+            log.error("응답 본문: {}", e.getResponseBodyAsString());
+            throw new KakaoApiException(
+                    "카카오 토큰 교환 중 오류가 발생했습니다: " + e.getStatusCode(),
+                    e,
+                    e.getStatusCode().value()
+            );
+        } catch (Exception e) {
+            log.error("카카오 토큰 교환 중 오류 발생: {}", e.getMessage(), e);
+            throw new KakaoApiException("카카오 토큰 교환 중 오류가 발생했습니다", e);
         }
     }
 
@@ -57,8 +143,6 @@ public class KakaoApiService implements InitializingBean {
 
             HttpEntity<String> entity = new HttpEntity<>(headers);
 
-            // 이메일을 포함한 사용자 정보 요청 (동의항목에 포함된 경우)
-            // property_keys 파라미터를 사용하여 필요한 정보만 명시적으로 요청
             String url = kakaoApiBaseUrl + "/v2/user/me?property_keys=[\"kakao_account.email\"]";
             ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
                     url,
@@ -139,9 +223,6 @@ public class KakaoApiService implements InitializingBean {
             private String profileImage;
         }
 
-        /**
-         * 이메일 추출 (kakao_account.email 우선, 없으면 null)
-         */
         public String getEmail() {
             if (kakaoAccount != null && kakaoAccount.getEmail() != null) {
                 return kakaoAccount.getEmail();
@@ -149,9 +230,6 @@ public class KakaoApiService implements InitializingBean {
             return null;
         }
 
-        /**
-         * 닉네임 추출 (properties.nickname 우선, 없으면 kakao_account.profile.nickname)
-         */
         public String getNickname() {
             if (properties != null && properties.getNickname() != null) {
                 return properties.getNickname();
@@ -164,4 +242,3 @@ public class KakaoApiService implements InitializingBean {
         }
     }
 }
-

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,4 +18,16 @@ app:
 
 oauth:
   kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
+    authorize-uri: https://kauth.kakao.com/oauth/authorize
+    token-uri: https://kauth.kakao.com/oauth/token
     redirect-uri: https://seok-hwan1.duckdns.org/api/auth/kakao/callback
+
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    authorize-uri: https://nid.naver.com/oauth2.0/authorize
+    token-uri: https://nid.naver.com/oauth2.0/token
+    redirect-uri: https://seok-hwan1.duckdns.org/api/auth/naver/callback
+


### PR DESCRIPTION
# OAuth 로그인 구현 정리 (Kakao / Naver)

본 문서는 **Unimate 백엔드에서 구현한 카카오·네이버 OAuth 로그인 구조**와  
**프론트엔드–백엔드 간 역할 분리 및 전체 인증 흐름**을 정리한 문서이다.

---

## 1. 전체 구조 요약

> **백엔드는 OAuth “시작 URL”을 제공하고,  
프론트엔드는 실제 OAuth 흐름을 완성하여 Access Token을 발급한 뒤,  
그 Access Token을 다시 백엔드에 전달한다.**

즉, **프론트엔드가 OAuth 플로우의 주체**이며  
백엔드는 **사용자 식별 + JWT 발급**에 집중한다.

---

## 2. 역할 분리 (중요)

### 프론트엔드 역할
- OAuth 로그인 시작
- Authorization Code 수신
- **Access Token 발급**
- Access Token을 백엔드에 전달

### 백엔드 역할
- authorize-url 생성
- OAuth Access Token으로 사용자 정보 조회
- 회원 upsert (신규/기존 구분)
- 서비스용 JWT 발급

---

## 3. OAuth 전체 흐름 (단계별)

### STEP 1. 로그인 버튼 클릭 (프론트엔드)

```http
GET /api/auth/naver/authorize-url
GET /api/auth/kakao/authorize-url
