### PR TITLE
feat/#44: 알람 형태 초기 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/alarm/controller/FcmController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/controller/FcmController.java
@@ -1,13 +1,17 @@
-// ✅ FcmController.java (서버만으로 검증 가능한 디버그 엔드포인트 포함 "풀버전")
-// package 경로는 네 프로젝트에 맞춰 그대로 유지
-
 package com.gdg.unimatebackend.app.alarm.controller;
 
 import com.gdg.unimatebackend.app.alarm.dto.FcmSendDto;
+import com.gdg.unimatebackend.app.alarm.dto.FcmTestSendRequest;
+import com.gdg.unimatebackend.app.alarm.dto.FcmTokenRegisterRequest;
+import com.gdg.unimatebackend.app.alarm.entity.FcmDeviceToken;
+import com.gdg.unimatebackend.app.alarm.repository.FcmDeviceTokenRepository;
 import com.gdg.unimatebackend.app.alarm.service.FcmService;
+import com.gdg.unimatebackend.app.alarm.service.FcmTokenService;
+import com.gdg.unimatebackend.app.alarm.support.UserIdResolver;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,45 +19,77 @@ import java.io.IOException;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/fcm")
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/fcm")
 public class FcmController {
 
     private final FcmService fcmService;
+    private final FcmTokenService fcmTokenService;
+    private final FcmDeviceTokenRepository tokenRepository;
+    private final UserIdResolver userIdResolver;
 
     /**
-     * ✅ 1) 서버만으로 "키 파일 로딩 + OAuth AccessToken 발급" 확인
-     * - 프론트 토큰 없어도 됨
+     * ✅ 앱 → 서버: 토큰 등록
+     * - 지금은 테스트 편하게 X-USER-ID 헤더로 userId 받음
      */
-    @GetMapping("/debug/access-token")
-    public ResponseEntity<String> debugAccessToken() throws IOException {
-        String accessToken = fcmService.getAccessTokenForDebug();
-
-        // 로그에는 마스킹 유지 (좋은 습관)
-        String masked = accessToken.length() > 20 ? accessToken.substring(0, 20) + "..." : accessToken;
-        log.info("[FCM DEBUG] accessToken(masked)={}", masked);
-
-        // 응답은 전체 반환
-        return ResponseEntity.ok(accessToken);
+    @PostMapping(value = "/token", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> registerToken(
+            @RequestHeader(value = "X-USER-ID", required = false) String headerUserId,
+            @Valid @RequestBody FcmTokenRegisterRequest request
+    ) {
+        Long userId = userIdResolver.resolveOrThrow(headerUserId);
+        fcmTokenService.register(userId, request);
+        return ResponseEntity.ok().build();
     }
 
     /**
-     * ✅ 2) 서버만으로 "FCM HTTP v1 호출"이 되는지 확인
-     * - token이 가짜여도 됨 (그 경우 400 INVALID_ARGUMENT이 정상적인 결과)
-     * - 401/403이면 인증/권한/프로젝트ID/키파일 문제가 있는 것
+     * ✅ 서버 단독: 내 저장된 토큰으로 템플릿 발송
+     * - body/title 없으면 기본값
      */
-    @PostMapping("/debug/send-dummy")
+    @PostMapping(value = "/test/me", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> testSendToMe(
+            @RequestHeader(value = "X-USER-ID", required = false) String headerUserId,
+            @RequestBody(required = false) FcmTestSendRequest request
+    ) throws IOException {
+
+        Long userId = userIdResolver.resolveOrThrow(headerUserId);
+
+        FcmDeviceToken token = tokenRepository.findTopByUserIdAndIsActiveTrueOrderByUpdatedAtDesc(userId)
+                .orElseThrow(() -> new IllegalStateException("No active FCM token for userId=" + userId));
+
+        String title = (request == null || request.getTitle() == null || request.getTitle().isBlank())
+                ? "Unimate Test"
+                : request.getTitle();
+
+        String body = (request == null || request.getBody() == null || request.getBody().isBlank())
+                ? "서버 템플릿 발송 테스트"
+                : request.getBody();
+
+        String result = fcmService.sendMessageTo(FcmSendDto.builder()
+                .token(token.getToken())
+                .title(title)
+                .body(body)
+                .build());
+
+        return ResponseEntity.ok(result);
+    }
+
+    // ====== 기존 디버그 (유지) ======
+
+    @GetMapping(value = "/debug/access-token", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> debugAccessToken() throws IOException {
+        String accessToken = fcmService.getAccessTokenForDebug();
+        return ResponseEntity.ok(accessToken);
+    }
+
+    @PostMapping(value = "/debug/send-dummy", produces = MediaType.TEXT_PLAIN_VALUE)
     public ResponseEntity<String> sendDummy() throws IOException {
         String result = fcmService.sendDummyMessageForDebug();
         return ResponseEntity.ok(result);
     }
 
-    /**
-     * ✅ 3) 실제 전송 API (토큰이 있을 때)
-     * - Swagger에서 body로 token/title/body 넣어서 호출
-     */
-    @PostMapping("/debug/send")
-    public ResponseEntity<String> send(@RequestBody @Valid FcmSendDto dto) throws IOException {
+    @PostMapping(value = "/debug/send", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> send(@RequestBody FcmSendDto dto) throws IOException {
         String result = fcmService.sendMessageTo(dto);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/dto/FcmTestSendRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/dto/FcmTestSendRequest.java
@@ -1,0 +1,10 @@
+package com.gdg.unimatebackend.app.alarm.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FcmTestSendRequest {
+    // 없으면 기본 템플릿으로 발송
+    private String title;
+    private String body;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/dto/FcmTokenRegisterRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/dto/FcmTokenRegisterRequest.java
@@ -1,0 +1,17 @@
+package com.gdg.unimatebackend.app.alarm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class FcmTokenRegisterRequest {
+
+    @NotBlank
+    private String token;
+
+    // 선택: 기기 식별자(에뮬레이터/실기기 구분용)
+    private String deviceId;
+
+    // 선택: ANDROID
+    private String platform;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/entity/FcmDeviceToken.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/entity/FcmDeviceToken.java
@@ -1,0 +1,74 @@
+package com.gdg.unimatebackend.app.alarm.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "fcm_device_token",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_fcm_device_token_token", columnNames = "token")
+        },
+        indexes = {
+                @Index(name = "idx_fcm_device_token_user", columnList = "user_id"),
+                @Index(name = "idx_fcm_device_token_active", columnList = "is_active")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class FcmDeviceToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // "test/me"용: 로그인된 사용자와 매핑
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(nullable = false, length = 512)
+    private String token;
+
+    @Column(name = "device_id", length = 128)
+    private String deviceId;
+
+    @Column(length = 32)
+    private String platform; // ANDROID / IOS 등
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        this.isActive = true;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void activateForUser(Long userId, String deviceId, String platform) {
+        this.userId = userId;
+        this.deviceId = deviceId;
+        this.platform = platform;
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/repository/FcmDeviceTokenRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/repository/FcmDeviceTokenRepository.java
@@ -1,0 +1,14 @@
+package com.gdg.unimatebackend.app.alarm.repository;
+
+import com.gdg.unimatebackend.app.alarm.entity.FcmDeviceToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FcmDeviceTokenRepository extends JpaRepository<FcmDeviceToken, Long> {
+
+    Optional<FcmDeviceToken> findByToken(String token);
+
+    // "내 토큰" 하나를 최신으로 가져오고 싶으면 updatedAt DESC 방식도 가능
+    Optional<FcmDeviceToken> findTopByUserIdAndIsActiveTrueOrderByUpdatedAtDesc(Long userId);
+}

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/service/FcmTokenService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/service/FcmTokenService.java
@@ -1,0 +1,7 @@
+package com.gdg.unimatebackend.app.alarm.service;
+
+import com.gdg.unimatebackend.app.alarm.dto.FcmTokenRegisterRequest;
+
+public interface FcmTokenService {
+    void register(Long userId, FcmTokenRegisterRequest request);
+}

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmServiceImpl.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmServiceImpl.java
@@ -2,7 +2,6 @@ package com.gdg.unimatebackend.app.alarm.service.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gdg.unimatebackend.app.alarm.dto.FcmMessageDto;
 import com.gdg.unimatebackend.app.alarm.dto.FcmSendDto;
 import com.gdg.unimatebackend.app.alarm.service.FcmService;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -17,9 +16,11 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -29,9 +30,7 @@ public class FcmServiceImpl implements FcmService {
     private String projectId;
 
     /**
-     * 예시
-     *  - 운영(도커 마운트): /app/firebase-key.json   또는 file:/app/firebase-key.json
-     *  - 로컬(classpath):  classpath:firebase/unimate.json
+     * 예) file:/app/firebase-key.json
      */
     @Value("${fcm.key-path}")
     private String firebaseKeyPath;
@@ -44,8 +43,8 @@ public class FcmServiceImpl implements FcmService {
     }
 
     @Override
-    public String sendMessageTo(FcmSendDto fcmSendDto) throws IOException {
-        String jsonBody = makeMessage(fcmSendDto);
+    public String sendMessageTo(FcmSendDto dto) throws IOException {
+        String jsonBody = makeMessage(dto);
         return callFcmApi(jsonBody);
     }
 
@@ -75,13 +74,11 @@ public class FcmServiceImpl implements FcmService {
         headers.setBearerAuth(getAccessTokenInternal());
 
         HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
-
         String apiUrl = "https://fcm.googleapis.com/v1/projects/" + projectId + "/messages:send";
 
         try {
             ResponseEntity<String> response = restTemplate.exchange(apiUrl, HttpMethod.POST, entity, String.class);
-            log.info("[FCM] status={}", response.getStatusCode());
-            log.info("[FCM] body={}", response.getBody());
+            log.info("[FCM] status={}, body={}", response.getStatusCode(), response.getBody());
             return "OK: " + response.getBody();
         } catch (HttpStatusCodeException e) {
             log.error("[FCM] status={} body={}", e.getStatusCode(), e.getResponseBodyAsString());
@@ -89,64 +86,49 @@ public class FcmServiceImpl implements FcmService {
         }
     }
 
-    /**
-     * ✅ OAuth2 Access Token 발급 (classpath/file 모두 지원)
-     */
     private String getAccessTokenInternal() throws IOException {
-        Resource resource = resolveKeyResource(firebaseKeyPath);
+        Resource resource = resourceLoader.getResource(firebaseKeyPath);
 
-        try (InputStream is = resource.getInputStream()) {
-            GoogleCredentials credentials = GoogleCredentials.fromStream(is)
-                    // ✅ FCM HTTP v1 최소 권한 스코프
-                    .createScoped(List.of("https://www.googleapis.com/auth/firebase.messaging"));
+        GoogleCredentials credentials = GoogleCredentials
+                .fromStream(resource.getInputStream())
+                .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
 
-            credentials.refreshIfExpired();
-
-            if (credentials.getAccessToken() == null) {
-                credentials.refreshAccessToken();
-            }
-
-            return credentials.getAccessToken().getTokenValue();
+        credentials.refreshIfExpired();
+        if (credentials.getAccessToken() == null) {
+            credentials.refreshAccessToken();
         }
+
+        return credentials.getAccessToken().getTokenValue();
     }
 
     /**
-     * firebaseKeyPath가 classpath 접두어가 없고, "/"로 시작하면 file로 간주해준다.
+     * ✅ notification + data + android priority HIGH
      */
-    private Resource resolveKeyResource(String path) {
-        if (path == null || path.isBlank()) {
-            throw new IllegalStateException("fcm.key-path is blank");
-        }
+    private String makeMessage(FcmSendDto dto) throws JsonProcessingException {
+        Map<String, Object> root = new HashMap<>();
+        Map<String, Object> message = new HashMap<>();
 
-        String trimmed = path.trim();
+        message.put("token", dto.getToken());
 
-        // classpath:/ file:/ http: 같은 스킴이 이미 있으면 그대로 로딩
-        if (trimmed.contains(":")) {
-            return resourceLoader.getResource(trimmed);
-        }
+        // notification (배경에서 OS가 자동으로 띄움)
+        Map<String, String> notification = new HashMap<>();
+        notification.put("title", dto.getTitle());
+        notification.put("body", dto.getBody());
+        message.put("notification", notification);
 
-        // "/app/firebase-key.json" 같은 절대경로면 file로 처리
-        if (trimmed.startsWith("/")) {
-            return resourceLoader.getResource("file:" + trimmed);
-        }
+        // data (포그라운드/딥링크용 - 지금은 테스트 값)
+        Map<String, String> data = new HashMap<>();
+        data.put("type", "TEST");
+        data.put("sentAt", Instant.now().toString());
+        message.put("data", data);
 
-        // 그 외는 classpath로 처리 (예: "firebase/unimate.json")
-        return resourceLoader.getResource("classpath:" + trimmed);
-    }
+        // android priority
+        Map<String, Object> android = new HashMap<>();
+        android.put("priority", "HIGH");
+        message.put("android", android);
 
-    private String makeMessage(FcmSendDto fcmSendDto) throws JsonProcessingException {
-        FcmMessageDto payload = FcmMessageDto.builder()
-                .validateOnly(false)
-                .message(FcmMessageDto.Message.builder()
-                        .token(fcmSendDto.getToken())
-                        .notification(FcmMessageDto.Notification.builder()
-                                .title(fcmSendDto.getTitle())
-                                .body(fcmSendDto.getBody())
-                                .image(null)
-                                .build())
-                        .build())
-                .build();
+        root.put("message", message);
 
-        return objectMapper.writeValueAsString(payload);
+        return objectMapper.writeValueAsString(root);
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmTokenServiceImpl.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmTokenServiceImpl.java
@@ -1,0 +1,41 @@
+package com.gdg.unimatebackend.app.alarm.service.impl;
+
+import com.gdg.unimatebackend.app.alarm.dto.FcmTokenRegisterRequest;
+import com.gdg.unimatebackend.app.alarm.entity.FcmDeviceToken;
+import com.gdg.unimatebackend.app.alarm.repository.FcmDeviceTokenRepository;
+import com.gdg.unimatebackend.app.alarm.service.FcmTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmTokenServiceImpl implements FcmTokenService {
+
+    private final FcmDeviceTokenRepository tokenRepository;
+
+    @Override
+    @Transactional
+    public void register(Long userId, FcmTokenRegisterRequest request) {
+        String token = request.getToken().trim();
+
+        FcmDeviceToken entity = tokenRepository.findByToken(token)
+                .orElseGet(() -> FcmDeviceToken.builder()
+                        .token(token)
+                        .isActive(true)
+                        .build());
+
+        entity.activateForUser(
+                userId,
+                request.getDeviceId(),
+                request.getPlatform() == null ? "ANDROID" : request.getPlatform()
+        );
+
+        tokenRepository.save(entity);
+
+        log.info("[FCM] token registered. userId={}, deviceId={}, platform={}",
+                userId, request.getDeviceId(), entity.getPlatform());
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/support/UserIdResolver.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/support/UserIdResolver.java
@@ -1,0 +1,18 @@
+package com.gdg.unimatebackend.app.alarm.support;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserIdResolver {
+
+    /**
+     * TODO: JWT 연동되면 여기만 교체하면 됨.
+     * 지금은 테스트 편하게 "X-USER-ID"로 받는 방식 사용.
+     */
+    public Long resolveOrThrow(String headerUserId) {
+        if (headerUserId == null || headerUserId.isBlank()) {
+            throw new IllegalArgumentException("X-USER-ID header is required for now.");
+        }
+        return Long.parseLong(headerUserId);
+    }
+}


### PR DESCRIPTION
# Android(Kotlin) FCM 토큰 등록 구현 (최소 예시) — 자세한 가이드

목표:
- 앱이 실행되면 **FCM 토큰을 발급/가져오고**
- 서버의 `POST /api/v1/fcm/token` 으로 **토큰만 등록**한다
- (지금은 테스트 편의상) `X-USER-ID` 헤더를 같이 보낸다  
  → 나중에 JWT 붙으면 `Authorization: Bearer ...` 로 교체

---

## 0) 사전 체크리스트

### ✅ Firebase 설정 파일
- `app/google-services.json` 파일이 있어야 함  
  (Firebase Console → Project settings → General → Your apps → Download)

### ✅ Firebase Messaging SDK
- FCM 토큰 발급은 `com.google.firebase:firebase-messaging` 이 필요

---

## 1) Gradle 세팅

### 1-1) 프로젝트 `build.gradle` (프로젝트 레벨) 또는 `settings.gradle` 확인
보통 최신 템플릿이면 `plugins {}` 방식으로 되어 있을 텐데, 핵심은:
- Google services plugin 적용
- Firebase BOM + messaging 의존성 추가

### 1-2) `app/build.gradle` (모듈 레벨) 예시

```gradle
plugins {
    id 'com.android.application'
    id 'org.jetbrains.kotlin.android'
    id 'com.google.gms.google-services'  // ✅ 추가
}

android {
    namespace "com.project.unimate"
    compileSdk 36

    defaultConfig {
        applicationId "com.project.unimate"
        minSdk 24
        targetSdk 36
        versionCode 1
        versionName "1.0"
    }
}

dependencies {
    // ✅ Firebase BOM (버전 통합 관리)
    implementation platform("com.google.firebase:firebase-bom:33.6.0")
    implementation("com.google.firebase:firebase-messaging")

    // ✅ 네트워크(둘 중 하나 택1)
    implementation("com.squareup.okhttp3:okhttp:4.12.0")
    // 또는 Retrofit을 쓰고 있으면 Retrofit 기반으로 구현해도 됨
}
