### PR TITLE
fix/#44: token등록 방식 변경

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/alarm/repository/FcmDeviceTokenRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/repository/FcmDeviceTokenRepository.java
@@ -2,16 +2,57 @@ package com.gdg.unimatebackend.app.alarm.repository;
 
 import com.gdg.unimatebackend.app.alarm.entity.FcmDeviceToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FcmDeviceTokenRepository extends JpaRepository<FcmDeviceToken, Long> {
 
     Optional<FcmDeviceToken> findByToken(String token);
 
+    // ✅ user_id가 unique가 아니므로 "Top + Order"로 안전하게 가져오기
     Optional<FcmDeviceToken> findTopByUserIdAndIsActiveTrueOrderByUpdatedAtDesc(Long userId);
 
-    void deleteByUserId(Long userId);
+    // ✅ 필요하면 전체도 가져올 수 있게
+    List<FcmDeviceToken> findAllByUserId(Long userId);
 
-    Optional<FcmDeviceToken> findByUserId(Long userId);
+    @Modifying
+    @Transactional
+    @Query(value = """
+        INSERT INTO fcm_device_token
+          (created_at, updated_at, token, user_id, device_id, platform, is_active)
+        VALUES
+          (NOW(6), NOW(6), :token, :userId, :deviceId, :platform, b'1')
+        ON DUPLICATE KEY UPDATE
+          user_id = VALUES(user_id),
+          device_id = VALUES(device_id),
+          platform = VALUES(platform),
+          is_active = b'1',
+          updated_at = NOW(6)
+        """, nativeQuery = true)
+    int upsertByToken(
+            @Param("userId") Long userId,
+            @Param("token") String token,
+            @Param("deviceId") String deviceId,
+            @Param("platform") String platform
+    );
+
+    // ✅ "유저당 1개" 정책을 유지하려면, 등록 전에 기존 토큰을 비활성화하는 게 깔끔함
+    @Modifying
+    @Transactional
+    @Query(value = """
+        UPDATE fcm_device_token
+           SET is_active = b'0',
+               updated_at = NOW(6)
+         WHERE user_id = :userId
+        """, nativeQuery = true)
+    int deactivateAllByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Transactional
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmTokenServiceImpl.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmTokenServiceImpl.java
@@ -1,7 +1,6 @@
 package com.gdg.unimatebackend.app.alarm.service.impl;
 
 import com.gdg.unimatebackend.app.alarm.dto.FcmTokenRegisterRequest;
-import com.gdg.unimatebackend.app.alarm.entity.FcmDeviceToken;
 import com.gdg.unimatebackend.app.alarm.repository.FcmDeviceTokenRepository;
 import com.gdg.unimatebackend.app.alarm.service.FcmTokenService;
 import lombok.RequiredArgsConstructor;
@@ -19,39 +18,50 @@ public class FcmTokenServiceImpl implements FcmTokenService {
     @Override
     @Transactional
     public void register(Long userId, FcmTokenRegisterRequest request) {
-        String token = request.getToken().trim();
+        String token = normalizeToken(request.getToken());
 
-        // 1) JWT가 들어오는 사고를 백엔드에서 차단
+        // 1) JWT 같은 쓰레기 값 차단
         validateNotJwtLike(token);
 
-        // 2) (선택) 어떤 유저가 이미 이 토큰을 쓰고 있으면 "현재 유저"로 재할당
-        tokenRepository.findByToken(token).ifPresent(existingByToken -> {
-            if (existingByToken.getUserId() != null && !existingByToken.getUserId().equals(userId)) {
-                // 정책상 user당 1개니까: 이전 유저 토큰을 비활성화(or 삭제)하고 재할당하는 편이 안전
-                // 여기서는 "재할당" 선택
-            }
-        });
+        String deviceId = trimToNull(request.getDeviceId());
+        String platform = trimToNull(request.getPlatform());
 
-        // 3) 유저 기준으로 1개만 유지: 있으면 update, 없으면 create
-        FcmDeviceToken entity = tokenRepository.findByUserId(userId)
-                .orElseGet(() -> FcmDeviceToken.builder()
-                        .userId(userId)
-                        .isActive(true)
-                        .build());
+        // 2) (정책 선택) "유저당 활성 1개"를 강하게 유지하고 싶으면
+        //    기존 userId 토큰을 일단 비활성화하고 -> 이번 토큰을 활성 업서트
+        //    프론트가 중복호출해도 결과는 항상 동일(마지막 토큰 1개 active)
+        tokenRepository.deactivateAllByUserId(userId);
 
-        entity.activateForUser(userId, request.getDeviceId(), request.getPlatform());
-        entity.updateToken(token); // 아래 엔티티에 메서드 추가 추천
-        tokenRepository.save(entity);
+        // 3) 핵심: token unique 기반 업서트 (동시성 안전)
+        tokenRepository.upsertByToken(userId, token, deviceId, platform);
 
-        log.info("[FCM] token registered(1-per-user). userId={}, deviceId={}, platform={}",
-                userId, request.getDeviceId(), request.getPlatform());
+        log.info("[FCM] token upserted. userId={}, deviceId={}, platform={}, tokenPrefix={}",
+                userId, deviceId, platform, safePrefix(token));
+    }
+
+    private String normalizeToken(String token) {
+        if (token == null) throw new IllegalArgumentException("token is required");
+        String t = token.trim();
+        if (t.isEmpty()) throw new IllegalArgumentException("token is required");
+        return t;
+    }
+
+    private String trimToNull(String v) {
+        if (v == null) return null;
+        String t = v.trim();
+        return t.isEmpty() ? null : t;
     }
 
     private void validateNotJwtLike(String token) {
-        // JWT는 보통 "header.payload.signature" 형태(점 2개) + "eyJ"로 시작하는 경우가 많음
-        boolean looksLikeJwt = token.startsWith("eyJ") && token.chars().filter(ch -> ch == '.').count() == 2;
+        // JWT는 보통 "xxx.yyy.zzz" + "eyJ" 시작
+        long dotCount = token.chars().filter(ch -> ch == '.').count();
+        boolean looksLikeJwt = token.startsWith("eyJ") && dotCount == 2;
         if (looksLikeJwt) {
             throw new IllegalArgumentException("FCM token is invalid (looks like JWT).");
         }
+    }
+
+    private String safePrefix(String token) {
+        int n = Math.min(token.length(), 12);
+        return token.substring(0, n) + "...";
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/unimatebackend/config/SecurityConfig.java
@@ -33,43 +33,20 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // ✅ CORS 적용 (빈만 만들고 적용 안 하면 의미 없음)
-                .cors(cors -> {}) // withDefaults() 대체 형태
-
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                // ✅ 기본 로그인 기능 제거 (JWT 서버에서 필요 없음)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .logout(AbstractHttpConfigurer::disable)
-
-                // ✅ 401/403 응답 일관성 (디버깅 쉬워짐)
-                .exceptionHandling(eh -> eh
-                        .authenticationEntryPoint((req, res, ex) -> res.sendError(401))
-                        .accessDeniedHandler((req, res, ex) -> res.sendError(403))
-                )
-
                 .authorizeHttpRequests(auth -> auth
-                        // ✅ Preflight는 무조건 열어야 CORS가 안정적
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-
-                        // ✅ actuator health 하위까지 열기 (readiness/liveness 포함)
-                        .requestMatchers("/actuator/health/**").permitAll()
-
-                        // ✅ swagger
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
-
-                        // ✅ auth
+                        // public
+                        .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
 
-                        // ✅ FCM dev/test
-                        .requestMatchers("/api/v1/fcm/test/**").permitAll()
+                        // protected (FCM)
+                        .requestMatchers("/api/v1/fcm/token/**").authenticated()
+                        .requestMatchers("/api/v1/fcm/test/**").authenticated()
 
-                        // 나머지
                         .anyRequest().authenticated()
                 )
-
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/gdg/unimatebackend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gdg/unimatebackend/global/security/jwt/JwtAuthenticationFilter.java
@@ -56,8 +56,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return path.startsWith("/swagger-ui")
                 || path.startsWith("/v3/api-docs")
-                || path.equals("/actuator/health")
-                || path.startsWith("/api/auth/")
-                || path.startsWith("/api/v1/fcm/test/");
+                || path.startsWith("/actuator/health")
+                || path.startsWith("/api/auth/");
+        // ✅ /api/v1/fcm/** 는 필터 적용되게 빼기
     }
 }


### PR DESCRIPTION
oken 등록은 무조건 upsertByToken(userId, token, deviceId, platform)로 처리

“유저당 1개만 유지” 정책을 유지하려면 기존 userId 토큰들 비활성화 후 upsert

프론트가 실수로 2번 호출해도 DB unique(token) 충돌로 서버가 죽지 않음

토큰 재등록/갱신에도 안정적