### PR TITLE
feat/#44:fcm 등록키 기준 변경

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/alarm/controller/FcmController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/controller/FcmController.java
@@ -6,12 +6,9 @@ import com.gdg.unimatebackend.app.alarm.dto.FcmTokenRegisterRequest;
 import com.gdg.unimatebackend.app.alarm.service.FcmTestService;
 import com.gdg.unimatebackend.app.alarm.service.FcmTokenService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,29 +27,35 @@ public class FcmController {
     private final FcmTokenService fcmTokenService;
     private final FcmTestService fcmTestService;
 
-    /* =========================
-       FCM 토큰 등록
-       ========================= */
     @Operation(
             summary = "내 FCM 토큰 등록/갱신",
-            description =
-                    """
+            description = """
                     ## 목적
-                    현재 로그인한 사용자의 **FCM 디바이스 토큰을 서버(DB)에 저장/갱신**합니다.
+                    로그인한 사용자의 **FCM 토큰을 DB에 등록/갱신**합니다.
 
-                    ## 사용 순서(중요)
-                    1) 모바일 앱에서 FCM 토큰을 발급받음  
-                    2) 이 API(`/token/me`)로 토큰을 서버에 등록  
-                    3) 등록이 끝난 뒤 `/test/me`로 실제 푸시 발송 테스트
+                    ## 디바이스 식별 정책(서버 기준)
+                    - 등록키: (user_id, device_id, platform)
+                    - 같은 디바이스에서 토큰이 바뀌면 UPDATE
+                    - 다른 디바이스면 INSERT
+                    - (테스트 A안) 유저당 활성 1개만 유지 → 마지막으로 등록한 디바이스만 수신
 
-                    ## 동작 개요
-                    - 서버는 JWT 기반 인증을 통해 userId를 식별합니다.
-                    - 동일 유저의 기존 토큰은 정책에 따라 비활성화될 수 있습니다.
+                    ## 테스트 순서
+                    1) /api/v1/fcm/token/me 로 토큰 등록
+                    2) /api/v1/fcm/test/me 로 푸시 발송
+
+                    ## 요청 예시
+                    ```json
+                    {
+                      "token": "fcmToken...",
+                      "deviceId": "pixel4-uuid-or-android-id",
+                      "platform": "ANDROID"
+                    }
+                    ```
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "200", description = "등록 성공"),
-                    @ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료)")
+                    @ApiResponse(responseCode = "401", description = "인증 실패")
             }
     )
     @PostMapping(value = "/token/me", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -60,8 +63,8 @@ public class FcmController {
             Authentication authentication,
             @Valid @RequestBody FcmTokenRegisterRequest request
     ) {
-        Long userId = fcmTestService.extractUserId(authentication); // ✅ userId 추출 로직 단일화
-        if (userId == null) {
+        Long userId = fcmTestService.extractUserId(authentication);
+        if (userId == null || userId <= 0) {
             return ResponseEntity.status(401).build();
         }
 
@@ -69,43 +72,28 @@ public class FcmController {
         return ResponseEntity.ok().build();
     }
 
-    /* =========================
-       내게 테스트 알림
-       ========================= */
     @Operation(
             summary = "내 계정으로 푸시 테스트 발송",
-            description =
-                    """
+            description = """
                     ## 목적
-                    현재 로그인한 사용자에게 **테스트 푸시를 즉시 발송**합니다.
+                    현재 로그인한 사용자에게 테스트 푸시를 발송합니다.
 
-                    ## 사전 조건(가장 중요)
-                    - 반드시 먼저 `/api/v1/fcm/token/me` 를 호출해서 **FCM 토큰이 DB에 저장되어 있어야** 합니다.
-                    - DB에 활성 토큰(`is_active = true`)이 없으면 404로 실패합니다.
+                    ## 사전 조건
+                    - 먼저 /api/v1/fcm/token/me 로 토큰 등록이 되어 있어야 합니다.
+                    - 활성 토큰이 없으면 success=false로 내려갑니다.
 
                     ## 요청 Body(선택)
-                    - title/body를 생략하면 기본 템플릿으로 발송됩니다.
-
-                    ### 예시
                     ```json
                     {
                       "title": "now",
                       "body": "내용"
                     }
                     ```
-
-                    ## 결과 해석
-                    - success=true 이면 서버에서 FCM 호출 자체는 정상
-                    - 단, **단말에서 배너(헤드업) 표시 여부는 알림 채널/OS 설정/앱 상태(포그라운드/백그라운드)**에 따라 달라질 수 있습니다.
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "FCM 발송 시도 완료(성공/실패 상세는 body 참고)",
-                            content = @Content(schema = @Schema(implementation = FcmTestResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료)",
-                            content = @Content(schema = @Schema(implementation = FcmTestResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "활성 FCM 토큰 없음",
-                            content = @Content(schema = @Schema(implementation = FcmTestResponse.class)))
+                    @ApiResponse(responseCode = "200", description = "발송 시도 결과 반환"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패")
             }
     )
     @PostMapping(value = "/test/me", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
@@ -113,18 +101,8 @@ public class FcmController {
             Authentication authentication,
             @RequestBody(required = false) FcmSendRequest request
     ) {
-        if (authentication == null) {
-            return ResponseEntity.status(401).body(
-                    FcmTestResponse.builder()
-                            .success(false)
-                            .message("Unauthorized")
-                            .detail("Authentication is null")
-                            .build()
-            );
-        }
-
         Long userId = fcmTestService.extractUserId(authentication);
-        if (userId == null) {
+        if (userId == null || userId <= 0) {
             return ResponseEntity.status(401).body(
                     FcmTestResponse.builder()
                             .success(false)
@@ -134,8 +112,6 @@ public class FcmController {
             );
         }
 
-        FcmTestResponse response = fcmTestService.sendTestToUser(userId, request);
-        // 선택: status를 response.success에 맞춰 조절하고 싶으면 여기서 분기 가능
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(fcmTestService.sendTestToUser(userId, request));
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/dto/FcmTokenRegisterRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/dto/FcmTokenRegisterRequest.java
@@ -9,7 +9,7 @@ public class FcmTokenRegisterRequest {
     @NotBlank
     private String token;
 
-    // 선택: 디바이스 식별/플랫폼(운영에서 유용)
-    private String deviceId;
-    private String platform;
+    // 프론트에서 넣어주면 정책이 완벽히 동작함 (권장)
+    private String deviceId;   // 예: ANDROID_ID / UUID 등
+    private String platform;   // 예: ANDROID
 }

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/entity/FcmDeviceToken.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/entity/FcmDeviceToken.java
@@ -9,11 +9,15 @@ import java.time.LocalDateTime;
 @Table(
         name = "fcm_device_token",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_fcm_device_token_token", columnNames = "token")
+                @UniqueConstraint(
+                        name = "uk_fcm_user_device_platform",
+                        columnNames = {"user_id", "device_id", "platform"}
+                )
         },
         indexes = {
                 @Index(name = "idx_fcm_device_token_user", columnList = "user_id"),
-                @Index(name = "idx_fcm_device_token_active", columnList = "is_active")
+                @Index(name = "idx_fcm_device_token_active", columnList = "is_active"),
+                @Index(name = "idx_fcm_token", columnList = "token")
         }
 )
 @Getter
@@ -26,7 +30,6 @@ public class FcmDeviceToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // "test/me"용: 로그인된 사용자와 매핑
     @Column(name = "user_id")
     private Long userId;
 
@@ -61,16 +64,10 @@ public class FcmDeviceToken {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void activateForUser(Long userId, String deviceId, String platform) {
-        this.userId = userId;
-        this.deviceId = deviceId;
-        this.platform = platform;
-        this.isActive = true;
-    }
-
     public void deactivate() {
         this.isActive = false;
     }
+
     public void updateToken(String token) {
         this.token = token;
     }

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/repository/FcmDeviceTokenRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/repository/FcmDeviceTokenRepository.java
@@ -12,12 +12,8 @@ import java.util.Optional;
 
 public interface FcmDeviceTokenRepository extends JpaRepository<FcmDeviceToken, Long> {
 
-    Optional<FcmDeviceToken> findByToken(String token);
-
-    // ✅ user_id가 unique가 아니므로 "Top + Order"로 안전하게 가져오기
     Optional<FcmDeviceToken> findTopByUserIdAndIsActiveTrueOrderByUpdatedAtDesc(Long userId);
 
-    // ✅ 필요하면 전체도 가져올 수 있게
     List<FcmDeviceToken> findAllByUserId(Long userId);
 
     @Modifying
@@ -28,20 +24,17 @@ public interface FcmDeviceTokenRepository extends JpaRepository<FcmDeviceToken, 
         VALUES
           (NOW(6), NOW(6), :token, :userId, :deviceId, :platform, b'1')
         ON DUPLICATE KEY UPDATE
-          user_id = VALUES(user_id),
-          device_id = VALUES(device_id),
-          platform = VALUES(platform),
+          token = VALUES(token),
           is_active = b'1',
           updated_at = NOW(6)
         """, nativeQuery = true)
-    int upsertByToken(
+    int upsertByDevice(
             @Param("userId") Long userId,
             @Param("token") String token,
             @Param("deviceId") String deviceId,
             @Param("platform") String platform
     );
 
-    // ✅ "유저당 1개" 정책을 유지하려면, 등록 전에 기존 토큰을 비활성화하는 게 깔끔함
     @Modifying
     @Transactional
     @Query(value = """

--- a/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmTokenServiceImpl.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/service/impl/FcmTokenServiceImpl.java
@@ -18,34 +18,39 @@ public class FcmTokenServiceImpl implements FcmTokenService {
     @Override
     @Transactional
     public void register(Long userId, FcmTokenRegisterRequest request) {
-        String token = normalize(request.getToken());
-
+        String token = normalizeToken(request.getToken());
         validateNotJwtLike(token);
 
-        String deviceId = trimToNull(request.getDeviceId());
-        String platform = trimToNull(request.getPlatform());
+        String deviceId = normalizeDeviceId(request.getDeviceId());
+        String platform = normalizePlatform(request.getPlatform());
 
-        // 🔥 유저 기준 기존 토큰 비활성화
+        // ✅ A안: 유저당 활성 1개 (마지막 등록 디바이스만 수신)
         tokenRepository.deactivateAllByUserId(userId);
 
-        // 🔥 token unique 기반 업서트
-        tokenRepository.upsertByToken(userId, token, deviceId, platform);
+        // ✅ (user_id, device_id, platform) 기준 업서트
+        tokenRepository.upsertByDevice(userId, token, deviceId, platform);
 
-        log.info("[FCM] token registered. userId={}, tokenPrefix={}",
-                userId, token.substring(0, Math.min(12, token.length())));
+        log.info("[FCM] token registered. userId={}, platform={}, deviceId={}, tokenPrefix={}",
+                userId, platform, deviceId, token.substring(0, Math.min(12, token.length())));
     }
 
-    private String normalize(String token) {
+    private String normalizeToken(String token) {
         if (token == null || token.trim().isEmpty()) {
             throw new IllegalArgumentException("FCM token is required");
         }
         return token.trim();
     }
 
-    private String trimToNull(String v) {
-        if (v == null) return null;
-        String t = v.trim();
-        return t.isEmpty() ? null : t;
+    private String normalizeDeviceId(String v) {
+        // 프론트가 deviceId를 안 보내면 "디바이스 단위 식별"이 불가능해짐.
+        // 그래도 서버가 깨지지 않게 최소 폴백을 둔다.
+        if (v == null || v.trim().isEmpty()) return "UNKNOWN";
+        return v.trim();
+    }
+
+    private String normalizePlatform(String v) {
+        if (v == null || v.trim().isEmpty()) return "UNKNOWN";
+        return v.trim().toUpperCase();
     }
 
     private void validateNotJwtLike(String token) {


### PR DESCRIPTION
(user_id, device_id, platform)을 “디바이스 단위”로 식별하도록 했습니다
같은 디바이스에서 토큰이 바뀌면 update, 다른 디바이스면 insert 하게 했습니 
발송 정책은: 유저당 1개만 활성 → 마지막으로 등록한 디바이스만 받음