### PR TITLE
feat/#73: 팀스페이스 api 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/alarm/service/FcmTestService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/alarm/service/FcmTestService.java
@@ -7,6 +7,6 @@ import org.springframework.security.core.Authentication;
 public interface FcmTestService {
     Long extractUserId(Authentication authentication);
 
-    // ✅ request를 받아서 title/body 커스텀
+    // request를 받아서 title/body 커스텀
     FcmTestResponse sendTestToUser(Long userId, FcmSendRequest request);
 }

--- a/src/main/java/com/gdg/unimatebackend/app/team/controller/TeamController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/controller/TeamController.java
@@ -1,0 +1,194 @@
+package com.gdg.unimatebackend.app.team.controller;
+
+import com.gdg.unimatebackend.app.team.dto.*;
+import com.gdg.unimatebackend.app.team.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/teams")
+@Tag(name = "팀스페이스", description = "팀스페이스 생성/조회/수정/삭제/탈퇴/초대/참여 API")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @Operation(
+            summary = "팀 생성",
+            description = """
+                    팀스페이스를 생성합니다.
+                    - 생성자는 자동으로 팀장(LEADER)으로 가입됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<TeamResponse> create(
+            Authentication authentication,
+            @Valid @RequestBody TeamCreateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamService.createTeam(userId, request));
+    }
+
+    @Operation(
+            summary = "내 팀 목록 조회",
+            description = """
+                    내가 속한 팀 목록을 조회합니다.
+                    - 각 팀별로 myRole(내 역할), memberCount(팀원 수)를 함께 반환합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<List<TeamSummaryResponse>> getMyTeams(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamService.getMyTeams(userId));
+    }
+
+    @Operation(
+            summary = "팀 상세 조회",
+            description = """
+                    팀 상세 정보를 조회합니다.
+                    - 팀 정보(team) + 팀원 목록(members)
+                    - myRole(내 역할), memberCount(팀원 수) 포함
+                    - 팀 멤버만 접근 가능합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamDetailResponse> getDetail(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamService.getTeamDetail(userId, teamId));
+    }
+
+    @Operation(
+            summary = "팀 정보 수정",
+            description = """
+                    팀 정보를 수정합니다. (팀장만)
+                    - name/description/color 중 전달된 값만 반영됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PutMapping("/{teamId}")
+    public ResponseEntity<TeamResponse> update(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Valid @RequestBody TeamUpdateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamService.updateTeam(userId, teamId, request));
+    }
+
+    @Operation(
+            summary = "팀 삭제",
+            description = """
+                    팀을 삭제합니다. (팀장만)
+                    - 팀 삭제 시 팀원 데이터도 함께 정리됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{teamId}")
+    public ResponseEntity<Void> delete(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        teamService.deleteTeam(userId, teamId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "팀 탈퇴",
+            description = """
+                    팀에서 탈퇴합니다. (팀원만)
+                    - 팀장(LEADER)은 탈퇴할 수 없습니다. (정책: 팀 삭제 사용)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{teamId}/leave")
+    public ResponseEntity<Void> leave(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        teamService.leaveTeam(userId, teamId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "팀원 목록 조회",
+            description = """
+                    팀원 목록을 조회합니다.
+                    - 팀 멤버만 조회 가능합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/{teamId}/members")
+    public ResponseEntity<List<TeamMemberResponse>> members(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamService.getTeamMembers(userId, teamId));
+    }
+
+    @Operation(
+            summary = "초대코드 발급/재발급",
+            description = """
+                    팀 초대코드를 발급(또는 재발급)합니다. (팀장만)
+                    - 숫자 6자리
+                    - 발급 시점부터 10분 뒤 만료
+                    - 재발급 시 기존 코드는 즉시 교체됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/{teamId}/invite-code")
+    public ResponseEntity<TeamInviteCodeResponse> issueInviteCode(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamService.issueInviteCode(userId, teamId));
+    }
+
+    @Operation(
+            summary = "초대코드로 팀 참여",
+            description = """
+                    초대코드로 팀에 참여합니다.
+                    - 숫자 6자리 inviteCode 필요
+                    - 만료(10분)된 코드는 참여 불가
+                    - 이미 멤버면 성공 처리(멱등)
+                    - 참여 성공 시 (선택) '새 팀원 입장' 알림을 팀원들에게 발송할 수 있습니다.
+                    
+                    커스텀 에러 코드 예시:
+                    - INVITE_CODE_INVALID: 유효하지 않은 코드
+                    - INVITE_CODE_EXPIRED: 만료된 코드
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/join")
+    public ResponseEntity<TeamJoinResponse> join(
+            Authentication authentication,
+            @Valid @RequestBody TeamJoinRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamService.joinByInviteCode(userId, request));
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamCreateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamCreateRequest.java
@@ -1,0 +1,19 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class TeamCreateRequest {
+
+    @NotBlank
+    @Size(max = 50)
+    private String name;
+
+    @Size(max = 300)
+    private String description;
+
+    @Size(max = 30)
+    private String color;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamDetailResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamDetailResponse.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import com.gdg.unimatebackend.app.team.entity.TeamRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter @Builder
+public class TeamDetailResponse {
+    private TeamResponse team;
+    private List<TeamMemberResponse> members;
+    private TeamRole myRole;
+    private long memberCount;
+}
+

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamInviteCodeResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamInviteCodeResponse.java
@@ -1,0 +1,14 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TeamInviteCodeResponse {
+    private Long teamId;
+    private String inviteCode;          // 숫자 6자리
+    private LocalDateTime expiresAt;    // 발급 후 10분
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamJoinRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamJoinRequest.java
@@ -1,0 +1,13 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class TeamJoinRequest {
+
+    @NotBlank
+    @Pattern(regexp = "^[0-9]{6}$", message = "초대코드는 숫자 6자리여야 합니다")
+    private String inviteCode;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamJoinResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamJoinResponse.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import com.gdg.unimatebackend.app.team.entity.TeamRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TeamJoinResponse {
+    private TeamResponse team;
+    private TeamRole myRole;
+    private long memberCount;
+    private List<TeamMemberResponse> members;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamMemberResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamMemberResponse.java
@@ -1,0 +1,18 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import com.gdg.unimatebackend.app.team.entity.TeamRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TeamMemberResponse {
+    private Long userId;
+    private String nickname;
+    private String profileImageUrl;
+    private String universityName;
+    private TeamRole role;
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamResponse.java
@@ -1,0 +1,18 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TeamResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private String color;
+    private Long ownerUserId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamSummaryResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import com.gdg.unimatebackend.app.team.entity.TeamRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TeamSummaryResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private String color;
+
+    private TeamRole myRole;
+    private long memberCount;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamUpdateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.gdg.unimatebackend.app.team.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class TeamUpdateRequest {
+
+    @Size(max = 50)
+    private String name;
+
+    @Size(max = 300)
+    private String description;
+
+    @Size(max = 30)
+    private String color;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/entity/Team.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/entity/Team.java
@@ -1,0 +1,71 @@
+package com.gdg.unimatebackend.app.team.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "teams", // ✅ DB 테이블명과 일치
+        indexes = {
+                @Index(name = "idx_teams_owner", columnList = "owner_user_id")
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 60) // ✅ DB가 varchar(60)
+    private String name;
+
+    // DB에는 description/color 컬럼이 아직 없을 수도 있음.
+    // 이미 운영 DB에 없다면, 아래 2개는 "DDL 추가"하거나, 당장 쓰지 않으면 제거해도 됨.
+    @Column(length = 300)
+    private String description;
+
+    @Column(length = 30)
+    private String color;
+
+    @Column(name = "owner_user_id")
+    private Long ownerUserId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // ✅ teams 컬럼만 사용
+    @Column(name = "invite_code", length = 6, unique = true)
+    private String inviteCode;
+
+    @Column(name = "invite_code_expires_at")
+    private LocalDateTime inviteCodeExpiresAt;
+
+    public void issueInviteCode(String inviteCode, LocalDateTime expiresAt) {
+        this.inviteCode = inviteCode;
+        this.inviteCodeExpiresAt = expiresAt;
+    }
+
+    public void clearInviteCode() {
+        this.inviteCode = null;
+        this.inviteCodeExpiresAt = null;
+    }
+
+    public void update(String name, String description, String color) {
+        if (name != null && !name.isBlank()) this.name = name;
+        if (description != null) this.description = description;
+        if (color != null) this.color = color;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/entity/TeamMember.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/entity/TeamMember.java
@@ -1,0 +1,43 @@
+package com.gdg.unimatebackend.app.team.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "team_member",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_team_member_team_user", columnNames = {"team_id", "user_id"})
+        },
+        indexes = {
+                @Index(name = "idx_team_member_user", columnList = "user_id"),
+                @Index(name = "idx_team_member_team", columnList = "team_id")
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "team_id", nullable = false)
+    private Long teamId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TeamRole role;
+
+    @CreationTimestamp
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/entity/TeamRole.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/entity/TeamRole.java
@@ -1,0 +1,6 @@
+package com.gdg.unimatebackend.app.team.entity;
+
+public enum TeamRole {
+    LEADER,
+    MEMBER
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/exception/TeamErrorCodes.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/exception/TeamErrorCodes.java
@@ -1,0 +1,13 @@
+package com.gdg.unimatebackend.app.team.exception;
+
+public final class TeamErrorCodes {
+    private TeamErrorCodes() {}
+
+    public static final String TEAM_NOT_FOUND = "TEAM_NOT_FOUND";
+    public static final String NOT_A_MEMBER = "NOT_A_MEMBER";
+    public static final String FORBIDDEN = "FORBIDDEN";
+
+    public static final String INVITE_CODE_INVALID = "INVITE_CODE_INVALID";
+    public static final String INVITE_CODE_EXPIRED = "INVITE_CODE_EXPIRED";
+    public static final String LEADER_CANNOT_LEAVE = "LEADER_CANNOT_LEAVE";
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/exception/TeamException.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/exception/TeamException.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.app.team.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TeamException extends RuntimeException {
+    private final String code;
+    private final int status;
+
+    public TeamException(String code, String message, int status) {
+        super(message);
+        this.code = code;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/repository/TeamMemberRepository.java
@@ -1,0 +1,27 @@
+package com.gdg.unimatebackend.app.team.repository;
+
+import com.gdg.unimatebackend.app.team.entity.TeamMember;
+import com.gdg.unimatebackend.app.team.entity.TeamRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    boolean existsByTeamIdAndUserId(Long teamId, Long userId);
+
+    Optional<TeamMember> findByTeamIdAndUserId(Long teamId, Long userId);
+
+    List<TeamMember> findAllByTeamIdOrderByJoinedAtAsc(Long teamId);
+
+    List<TeamMember> findAllByUserIdOrderByJoinedAtDesc(Long userId);
+
+    long countByTeamId(Long teamId);
+
+    long countByTeamIdAndRole(Long teamId, TeamRole role);
+
+    void deleteByTeamIdAndUserId(Long teamId, Long userId);
+
+    void deleteAllByTeamId(Long teamId);
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/repository/TeamRepository.java
@@ -1,0 +1,13 @@
+package com.gdg.unimatebackend.app.team.repository;
+
+import com.gdg.unimatebackend.app.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    Optional<Team> findByInviteCode(String inviteCode);
+
+    boolean existsByInviteCode(String inviteCode);
+}

--- a/src/main/java/com/gdg/unimatebackend/app/team/service/TeamService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/service/TeamService.java
@@ -1,0 +1,317 @@
+package com.gdg.unimatebackend.app.team.service;
+
+import com.gdg.unimatebackend.app.team.dto.*;
+import com.gdg.unimatebackend.app.team.entity.*;
+import com.gdg.unimatebackend.app.team.exception.TeamException;
+import com.gdg.unimatebackend.app.team.exception.TeamErrorCodes;
+import com.gdg.unimatebackend.app.team.repository.TeamMemberRepository;
+import com.gdg.unimatebackend.app.team.repository.TeamRepository;
+import com.gdg.unimatebackend.app.user.entity.User;
+import com.gdg.unimatebackend.app.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final UserRepository userRepository;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    // ===== 팀 생성 =====
+    @Transactional
+    public TeamResponse createTeam(Long userId, TeamCreateRequest request) {
+        Team team = Team.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .color(request.getColor())
+                .ownerUserId(userId)
+                .build();
+
+        team = teamRepository.save(team);
+
+        // 생성자는 자동 LEADER 가입
+        teamMemberRepository.save(TeamMember.builder()
+                .teamId(team.getId())
+                .userId(userId)
+                .role(TeamRole.LEADER)
+                .build());
+
+        return toTeamResponse(team);
+    }
+
+    // ===== 팀 목록(요약) =====
+    @Transactional(readOnly = true)
+    public List<TeamSummaryResponse> getMyTeams(Long userId) {
+        List<TeamMember> memberships = teamMemberRepository.findAllByUserIdOrderByJoinedAtDesc(userId);
+        if (memberships.isEmpty()) return List.of();
+
+        List<Long> teamIdsOrdered = memberships.stream()
+                .map(TeamMember::getTeamId)
+                .distinct()
+                .toList();
+
+        Map<Long, Team> teamMap = teamRepository.findAllById(teamIdsOrdered).stream()
+                .collect(Collectors.toMap(Team::getId, t -> t));
+
+        Map<Long, TeamRole> myRoleMap = memberships.stream()
+                .collect(Collectors.toMap(TeamMember::getTeamId, TeamMember::getRole, (a, b) -> a));
+
+        List<TeamSummaryResponse> result = new ArrayList<>();
+        for (Long teamId : teamIdsOrdered) {
+            Team t = teamMap.get(teamId);
+            if (t == null) continue;
+
+            long memberCount = teamMemberRepository.countByTeamId(teamId);
+            TeamRole myRole = myRoleMap.get(teamId);
+
+            result.add(TeamSummaryResponse.builder()
+                    .id(t.getId())
+                    .name(t.getName())
+                    .description(t.getDescription())
+                    .color(t.getColor())
+                    .myRole(myRole)
+                    .memberCount(memberCount)
+                    .createdAt(t.getCreatedAt())
+                    .updatedAt(t.getUpdatedAt())
+                    .build());
+        }
+        return result;
+    }
+
+    // ===== 팀 상세(q3 반영) =====
+    @Transactional(readOnly = true)
+    public TeamDetailResponse getTeamDetail(Long userId, Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(
+                        TeamErrorCodes.TEAM_NOT_FOUND, "팀을 찾을 수 없습니다", 404
+                ));
+
+        TeamMember me = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+                .orElseThrow(() -> new TeamException(
+                        TeamErrorCodes.NOT_A_MEMBER, "팀 멤버만 접근할 수 있습니다", 403
+                ));
+
+        List<TeamMember> members = teamMemberRepository.findAllByTeamIdOrderByJoinedAtAsc(teamId);
+        List<TeamMemberResponse> memberResponses = buildMemberResponses(members);
+
+        return TeamDetailResponse.builder()
+                .team(toTeamResponse(team))
+                .members(memberResponses)
+                .myRole(me.getRole())
+                .memberCount(members.size())
+                .build();
+    }
+
+    // ===== 팀 정보 수정 =====
+    @Transactional
+    public TeamResponse updateTeam(Long userId, Long teamId, TeamUpdateRequest request) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(
+                        TeamErrorCodes.TEAM_NOT_FOUND, "팀을 찾을 수 없습니다", 404
+                ));
+
+        requireLeader(teamId, userId, team);
+
+        team.update(request.getName(), request.getDescription(), request.getColor());
+        return toTeamResponse(team);
+    }
+
+    // ===== 팀 삭제 =====
+    @Transactional
+    public void deleteTeam(Long userId, Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(
+                        TeamErrorCodes.TEAM_NOT_FOUND, "팀을 찾을 수 없습니다", 404
+                ));
+
+        requireLeader(teamId, userId, team);
+
+        teamMemberRepository.deleteAllByTeamId(teamId);
+        teamRepository.delete(team);
+    }
+
+    // ===== 팀 탈퇴 =====
+    @Transactional
+    public void leaveTeam(Long userId, Long teamId) {
+        TeamMember me = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+                .orElseThrow(() -> new TeamException(
+                        TeamErrorCodes.NOT_A_MEMBER, "팀 멤버가 아닙니다", 403
+                ));
+
+        if (me.getRole() == TeamRole.LEADER) {
+            throw new TeamException(
+                    TeamErrorCodes.LEADER_CANNOT_LEAVE, "팀장은 탈퇴할 수 없습니다. 팀 삭제를 사용해주세요", 400
+            );
+        }
+
+        teamMemberRepository.deleteByTeamIdAndUserId(teamId, userId);
+    }
+
+    // ===== 팀원 목록 조회 =====
+    @Transactional(readOnly = true)
+    public List<TeamMemberResponse> getTeamMembers(Long userId, Long teamId) {
+        // 멤버만 조회 가능
+        if (!teamMemberRepository.existsByTeamIdAndUserId(teamId, userId)) {
+            throw new TeamException(TeamErrorCodes.NOT_A_MEMBER, "팀 멤버만 접근할 수 있습니다", 403);
+        }
+
+        List<TeamMember> members = teamMemberRepository.findAllByTeamIdOrderByJoinedAtAsc(teamId);
+        return buildMemberResponses(members);
+    }
+
+    // ===== 초대코드 발급/재발급 (teams 컬럼 사용, 팀장만, 10분) =====
+    @Transactional
+    public TeamInviteCodeResponse issueInviteCode(Long userId, Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(
+                        TeamErrorCodes.TEAM_NOT_FOUND, "팀을 찾을 수 없습니다", 404
+                ));
+
+        requireLeader(teamId, userId, team);
+
+        String code = generateUnique6DigitCode();
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(10);
+
+        team.issueInviteCode(code, expiresAt);
+
+        return TeamInviteCodeResponse.builder()
+                .teamId(teamId)
+                .inviteCode(code)
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    // ===== 초대코드로 팀 참여 (teams 컬럼 사용) =====
+    @Transactional
+    public TeamJoinResponse joinByInviteCode(Long userId, TeamJoinRequest request) {
+
+        Team team = teamRepository.findByInviteCode(request.getInviteCode())
+                .orElseThrow(() -> new TeamException(
+                        TeamErrorCodes.INVITE_CODE_INVALID, "유효하지 않은 초대코드입니다", 400
+                ));
+
+        if (team.getInviteCodeExpiresAt() == null || team.getInviteCodeExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new TeamException(
+                    TeamErrorCodes.INVITE_CODE_EXPIRED, "초대코드가 만료되었습니다", 400
+            );
+        }
+
+        Long teamId = team.getId();
+
+        // ✅ 람다 트릭 제거 (createdHolder 같은 거 필요 없음)
+        Optional<TeamMember> existing = teamMemberRepository.findByTeamIdAndUserId(teamId, userId);
+
+        TeamMember me;
+        if (existing.isPresent()) {
+            me = existing.get();
+        } else {
+            me = teamMemberRepository.save(
+                    TeamMember.builder()
+                            .teamId(teamId)
+                            .userId(userId)
+                            .role(TeamRole.MEMBER)
+                            .build()
+            );
+        }
+
+        List<TeamMember> members = teamMemberRepository.findAllByTeamIdOrderByJoinedAtAsc(teamId);
+        List<TeamMemberResponse> memberResponses = buildMemberResponses(members);
+
+        return TeamJoinResponse.builder()
+                .team(toTeamResponse(team))
+                .myRole(me.getRole())
+                .memberCount(members.size())
+                .members(memberResponses)
+                .build();
+    }
+
+    // ===== helpers =====
+
+    private List<TeamMemberResponse> buildMemberResponses(List<TeamMember> members) {
+        List<Long> userIds = members.stream().map(TeamMember::getUserId).distinct().toList();
+        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+
+        return members.stream().map(m -> {
+            User u = userMap.get(m.getUserId());
+            return TeamMemberResponse.builder()
+                    .userId(m.getUserId())
+                    .nickname(u != null ? u.getNickname() : null)
+                    .profileImageUrl(u != null ? u.getProfileImageUrl() : null)
+                    .universityName(resolveUniversityName(u))
+                    .role(m.getRole())
+                    .joinedAt(m.getJoinedAt())
+                    .build();
+        }).toList();
+    }
+
+    /**
+     * ✅ 여기만 네 User 구조에 맞추면 'u.getUniversityName() 오류'가 사라짐
+     * - User에 getUniversity() 연관관계가 있으면: u.getUniversity().getName()
+     * - 문자열 필드면: u.getUniversityName()
+     */
+    private String resolveUniversityName(User u) {
+        if (u == null) return null;
+
+        // 1) 연관관계형 (가장 흔함)
+        try {
+            var uni = u.getUniversity(); // User에 getUniversity()가 없으면 catch로 이동
+            if (uni == null) return null;
+            return uni.getName();
+        } catch (Exception ignored) {
+            // 2) 문자열 필드형으로 fallback
+            try {
+                return (String) u.getClass().getMethod("getUniversityName").invoke(u);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
+
+    private String generateUnique6DigitCode() {
+        for (int i = 0; i < 20; i++) {
+            String code = String.format("%06d", RANDOM.nextInt(1_000_000));
+            if (!teamRepository.existsByInviteCode(code)) {
+                return code;
+            }
+        }
+        throw new TeamException("INVITE_CODE_GENERATION_FAILED", "초대코드 생성에 실패했습니다", 500);
+    }
+
+    private void requireLeader(Long teamId, Long userId, Team team) {
+        // 팀 생성자 기준 1차 체크
+        if (team.getOwnerUserId() != null && !Objects.equals(team.getOwnerUserId(), userId)) {
+            throw new TeamException(TeamErrorCodes.FORBIDDEN, "팀장만 가능한 작업입니다", 403);
+        }
+
+        // 멤버십/역할 체크
+        TeamMember me = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+                .orElseThrow(() -> new TeamException(TeamErrorCodes.NOT_A_MEMBER, "팀 멤버가 아닙니다", 403));
+
+        if (me.getRole() != TeamRole.LEADER) {
+            throw new TeamException(TeamErrorCodes.FORBIDDEN, "팀장만 가능한 작업입니다", 403);
+        }
+    }
+
+    private TeamResponse toTeamResponse(Team team) {
+        return TeamResponse.builder()
+                .id(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .color(team.getColor())
+                .ownerUserId(team.getOwnerUserId())
+                .createdAt(team.getCreatedAt())
+                .updatedAt(team.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdg/unimatebackend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.gdg.unimatebackend.global.exception;
 
+import com.gdg.unimatebackend.app.team.exception.TeamException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,28 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(TeamException.class)
+    public ResponseEntity<Map<String, Object>> handleTeamException(TeamException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(Map.of(
+                        "code", e.getCode(),
+                        "message", e.getMessage(),
+                        "status", e.getStatus()
+                ));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, Object>> handleRuntimeException(RuntimeException e) {
+        return ResponseEntity
+                .status(500)
+                .body(Map.of(
+                        "code", "INTERNAL_SERVER_ERROR",
+                        "message", e.getMessage(),
+                        "status", 500
+                ));
+    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {


### PR DESCRIPTION
# TeamSpace API 개발 정리 (Backend)

> ✅ 상태: **배포 완료 / Swagger 테스트 정상 / RDS 스키마 정합성 확보**

이 문서는 **지금까지 구현·수정한 TeamSpace(팀스페이스) 관련 백엔드 작업을 한 번에 정리한 문서**입니다.  
GitHub README / Wiki / Notion 어디든 그대로 복붙해서 사용 가능합니다.

---

## 1. 개요

TeamSpace는 다음 기능을 제공합니다.

- 팀 생성
- 내가 속한 팀 목록 조회
- 팀 상세 조회 (멤버 포함)
- 팀 수정
- 팀 삭제 (팀장만 가능)
- 팀 탈퇴
- 초대코드 발급 (숫자 6자리, 10분 유효)
- 초대코드로 팀 참여

인증은 **JWT 기반**이며, 모든 팀 API는 인증 필요합니다.

---

## 2. API 목록 요약

| 기능 | Method | URL | 설명 |
|---|---|---|---|
| 팀 생성 | POST | `/api/teams` | 팀 생성 + 생성자는 자동 팀장 |
| 팀 목록 조회 | GET | `/api/teams` | 내가 속한 팀 목록 |
| 팀 상세 조회 | GET | `/api/teams/{teamId}` | 팀 정보 + 멤버 목록 |
| 팀 정보 수정 | PUT | `/api/teams/{teamId}` | 팀 이름/설명/색상 수정 |
| 팀 삭제 | DELETE | `/api/teams/{teamId}` | 팀 삭제 (팀장만) |
| 팀 탈퇴 | DELETE | `/api/teams/{teamId}/leave` | 팀에서 나가기 |
| 초대코드 발급 | POST | `/api/teams/{teamId}/invite-code` | 6자리 초대코드 발급 |
| 팀 참여 | POST | `/api/teams/join` | 초대코드로 팀 참여 |

---
4. 핵심 설계 포인트
4.1 팀 생성

생성자는 자동으로 LEADER

team_member에 즉시 insert

created_at, joined_at은 DB DEFAULT로 처리

4.2 팀 삭제


팀장만 가능

성공 시 204 No Content 반환

Swagger 문서도 204로 맞춤

4.3 초대코드


숫자 6자리

유효시간 10분

teams.invite_code, invite_code_expires_at 컬럼만 사용

별도 초대 테이블 사용 안 함

4.4 팀 참여


초대코드 유효성 검사

이미 멤버면 기존 멤버 반환

신규면 MEMBER로 가입

중복 가입은 DB 유니크 인덱스로 차단

---
