### PR TITLE
feat/#78: 개인일정 api 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/schedule/controller/MyScheduleController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/controller/MyScheduleController.java
@@ -1,0 +1,207 @@
+package com.gdg.unimatebackend.app.schedule.controller;
+
+import com.gdg.unimatebackend.app.schedule.dto.*;
+import com.gdg.unimatebackend.app.schedule.service.MyScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/teams/{teamId}/my-schedules")
+@Tag(
+        name = "개인일정",
+        description = """
+                팀 내부에서 사용하는 개인 일정 API입니다.
+
+                📌 설계 규칙
+                - 모든 일정은 시간 기반(startAt / endAt)으로 관리됩니다.
+                - 하루 종일 일정은 startAt=00:00, endAt=다음날 00:00 형태로 표현합니다.
+                - '지금 기준 바쁨 여부'는 startAt <= now < endAt 조건으로 판단합니다.
+                """
+)
+public class MyScheduleController {
+
+    private final MyScheduleService myScheduleService;
+
+    @Operation(
+            summary = "개인 일정 생성",
+            description = """
+                    로그인한 사용자의 팀 내부 개인 일정을 생성합니다.
+
+                    📌 규칙
+                    - 모든 일정은 startAt / endAt 시간을 반드시 포함해야 합니다.
+                    - 하루 종일 일정의 경우:
+                      startAt = YYYY-MM-DDT00:00,
+                      endAt = (다음날)T00:00 으로 전달해야 합니다.
+                    - isPrivate=true 인 경우, 향후 팀 공유 화면에서
+                      제목/메모가 비공개 처리될 수 있습니다.
+
+                    📌 사용처
+                    - 개인 일정 관리
+                    - 현재 시각 기준 Busy/Idle 판단
+                    - 캘린더 마킹
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<MyScheduleResponse> create(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Valid @RequestBody MyScheduleCreateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(myScheduleService.create(userId, teamId, request));
+    }
+
+    @Operation(
+            summary = "월/기간 단위 개인 일정 조회 (캘린더 마킹용)",
+            description = """
+                    로그인한 사용자의 개인 일정 중,
+                    특정 기간 내 일정이 존재하는 날짜 목록을 반환합니다.
+
+                    📌 특징
+                    - 날짜 단위로만 반환합니다 (시간 정보 없음)
+                    - 하루에 일정이 하나라도 존재하면 해당 날짜가 포함됩니다.
+
+                    📌 사용처
+                    - 캘린더 월뷰/주뷰 마킹
+                    - 일정 존재 여부 표시
+
+                    📌 파라미터
+                    - from/to는 YYYY-MM-DD 형식의 날짜입니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<MyScheduleMarkingResponse> getMarkedDates(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "조회 시작 날짜 (YYYY-MM-DD)", example = "2026-02-01")
+            @RequestParam LocalDate from,
+            @Parameter(description = "조회 종료 날짜 (YYYY-MM-DD)", example = "2026-02-28")
+            @RequestParam LocalDate to
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(myScheduleService.getMarkedDates(userId, teamId, from, to));
+    }
+
+    @Operation(
+            summary = "개인 일정 수정 (본인만)",
+            description = """
+                    본인이 생성한 개인 일정만 수정할 수 있습니다.
+
+                    📌 규칙
+                    - startAt / endAt은 항상 시간 범위를 만족해야 합니다.
+                    - endAt은 startAt 이후여야 합니다.
+
+                    📌 사용처
+                    - 개인 일정 시간/내용 수정
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PutMapping("/{scheduleId}")
+    public ResponseEntity<MyScheduleResponse> update(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "개인 일정 ID", example = "10")
+            @PathVariable Long scheduleId,
+            @Valid @RequestBody MyScheduleUpdateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(myScheduleService.update(userId, teamId, scheduleId, request));
+    }
+
+    @Operation(
+            summary = "개인 일정 삭제 (본인만)",
+            description = """
+                    본인이 생성한 개인 일정만 삭제할 수 있습니다.
+
+                    📌 주의
+                    - 삭제된 일정은 복구할 수 없습니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> delete(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "개인 일정 ID", example = "10")
+            @PathVariable Long scheduleId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        myScheduleService.delete(userId, teamId, scheduleId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "현재 시각 기준 개인 일정 상태 (Busy/Idle)",
+            description = """
+                    로그인한 사용자의 '현재 시각 기준' 개인 일정 상태를 조회합니다.
+
+                    📌 Busy 판단 기준
+                    - startAt <= 현재 시각 < endAt 인 일정이 하나라도 존재하면 Busy
+
+                    📌 응답
+                    - isBusy: 현재 바쁜 상태인지 여부
+                    - schedules: 현재 시각과 겹치는 일정 목록
+
+                    📌 사용처
+                    - 팀원 상태 표시 (지금 바쁨/한가함)
+                    - 찌르기/알림 가능 여부 판단
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/now")
+    public ResponseEntity<MyScheduleNowResponse> getNowStatus(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(myScheduleService.getNowStatus(userId, teamId));
+    }
+
+    @Operation(
+            summary = "특정 날짜의 개인 일정 목록 조회",
+            description = """
+                    로그인한 사용자의 특정 날짜에 해당하는 개인 일정 목록을 조회합니다.
+
+                    📌 특징
+                    - 시간 범위(startAt/endAt)를 그대로 반환합니다.
+                    - 하루 종일 일정도 00:00~다음날 00:00 형태로 포함됩니다.
+
+                    📌 사용처
+                    - 일별 일정 상세 화면
+                    - 디버깅 및 QA 확인
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/day")
+    public ResponseEntity<List<MyScheduleResponse>> getDaySchedules(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2026-02-10")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(
+                myScheduleService.getDaySchedules(userId, teamId, date)
+        );
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleCreateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleCreateRequest.java
@@ -1,0 +1,25 @@
+package com.gdg.unimatebackend.app.schedule.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MyScheduleCreateRequest {
+
+    @NotBlank
+    private String title;
+
+    private String memo;
+
+    @NotNull
+    private LocalDateTime startAt;
+
+    @NotNull
+    private LocalDateTime endAt;
+
+    @NotNull
+    private Boolean isPrivate;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleMarkingResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleMarkingResponse.java
@@ -1,0 +1,13 @@
+package com.gdg.unimatebackend.app.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MyScheduleMarkingResponse {
+    private List<LocalDate> markedDates; // 일정이 존재하는 날짜들
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleNowResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleNowResponse.java
@@ -1,0 +1,26 @@
+package com.gdg.unimatebackend.app.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MyScheduleNowResponse {
+
+    private boolean isBusy;
+
+    // 지금 시각과 겹치는 일정들
+    private List<ScheduleTimeRange> schedules;
+
+    @Getter
+    @AllArgsConstructor
+    public static class ScheduleTimeRange {
+        private Long scheduleId;
+        private String title;
+        private LocalDateTime startAt;
+        private LocalDateTime endAt;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleResponse.java
@@ -1,0 +1,25 @@
+package com.gdg.unimatebackend.app.schedule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyScheduleResponse {
+    private Long id;
+    private Long teamId;
+    private Long userId;
+
+    private String title;
+    private String memo;
+
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+
+    private boolean isPrivate;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleUpdateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/dto/MyScheduleUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.gdg.unimatebackend.app.schedule.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MyScheduleUpdateRequest {
+
+    @NotBlank
+    private String title;
+
+    private String memo;
+
+    @NotNull
+    private LocalDateTime startAt;
+
+    @NotNull
+    private LocalDateTime endAt;
+
+    @NotNull
+    private Boolean isPrivate;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/entity/MySchedule.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/entity/MySchedule.java
@@ -1,0 +1,70 @@
+package com.gdg.unimatebackend.app.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "my_schedule",
+        indexes = {
+                @Index(name = "idx_my_schedule_team_user", columnList = "team_id, user_id"),
+                @Index(name = "idx_my_schedule_start_end", columnList = "start_at, end_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MySchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="team_id", nullable = false)
+    private Long teamId;
+
+    @Column(name="user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 80)
+    private String title;
+
+    @Column(name="memo", length = 500)
+    private String memo;
+
+    @Column(name="start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name="end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @Column(name="is_private", nullable = false)
+    private boolean isPrivate;
+
+    @CreationTimestamp
+    @Column(name="created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name="updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void update(
+            String title,
+            String memo,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            boolean isPrivate
+    ) {
+        this.title = title;
+        this.memo = memo;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.isPrivate = isPrivate;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/exception/MyScheduleErrorCodes.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/exception/MyScheduleErrorCodes.java
@@ -1,0 +1,10 @@
+package com.gdg.unimatebackend.app.schedule.exception;
+
+public final class MyScheduleErrorCodes {
+    private MyScheduleErrorCodes() {}
+
+    public static final String NOT_A_MEMBER = "NOT_A_MEMBER";
+    public static final String SCHEDULE_NOT_FOUND = "SCHEDULE_NOT_FOUND";
+    public static final String FORBIDDEN = "FORBIDDEN";
+    public static final String INVALID_RANGE = "INVALID_RANGE";
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/exception/MyScheduleException.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/exception/MyScheduleException.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.app.schedule.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MyScheduleException extends RuntimeException {
+    private final String code;
+    private final int status;
+
+    public MyScheduleException(String code, String message, int status) {
+        super(message);
+        this.code = code;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/repository/MyScheduleRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/repository/MyScheduleRepository.java
@@ -1,0 +1,54 @@
+package com.gdg.unimatebackend.app.schedule.repository;
+
+import com.gdg.unimatebackend.app.schedule.entity.MySchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface MyScheduleRepository extends JpaRepository<MySchedule, Long> {
+
+    Optional<MySchedule> findByIdAndTeamId(Long id, Long teamId);
+
+    /**
+     * 기간 겹침(overlap) 조회:
+     * start < rangeEnd AND end > rangeStart
+     */
+    @Query("""
+        select s
+        from MySchedule s
+        where s.teamId = :teamId
+          and s.userId = :userId
+          and s.startAt < :rangeEnd
+          and s.endAt > :rangeStart
+        order by s.startAt asc
+    """)
+    List<MySchedule> findOverlaps(
+            @Param("teamId") Long teamId,
+            @Param("userId") Long userId,
+            @Param("rangeStart") LocalDateTime rangeStart,
+            @Param("rangeEnd") LocalDateTime rangeEnd
+    );
+
+    /**
+     * 지금 시각 기준 Busy 일정 조회:
+     * startAt <= now AND endAt > now
+     */
+    @Query("""
+        select s
+        from MySchedule s
+        where s.teamId = :teamId
+          and s.userId = :userId
+          and s.startAt <= :now
+          and s.endAt > :now
+        order by s.startAt asc
+    """)
+    List<MySchedule> findNowOverlaps(
+            @Param("teamId") Long teamId,
+            @Param("userId") Long userId,
+            @Param("now") LocalDateTime now
+    );
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/service/MyScheduleService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/service/MyScheduleService.java
@@ -1,0 +1,201 @@
+package com.gdg.unimatebackend.app.schedule.service;
+
+import com.gdg.unimatebackend.app.schedule.dto.*;
+import com.gdg.unimatebackend.app.schedule.entity.MySchedule;
+import com.gdg.unimatebackend.app.schedule.exception.MyScheduleErrorCodes;
+import com.gdg.unimatebackend.app.schedule.exception.MyScheduleException;
+import com.gdg.unimatebackend.app.schedule.repository.MyScheduleRepository;
+import com.gdg.unimatebackend.app.team.repository.TeamMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class MyScheduleService {
+
+    private final MyScheduleRepository myScheduleRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    @Transactional
+    public MyScheduleResponse create(Long userId, Long teamId, MyScheduleCreateRequest request) {
+        requireMember(teamId, userId);
+        validateRange(request.getStartAt(), request.getEndAt());
+
+        MySchedule saved = myScheduleRepository.save(
+                MySchedule.builder()
+                        .teamId(teamId)
+                        .userId(userId)
+                        .title(request.getTitle())
+                        .memo(request.getMemo())
+                        .startAt(request.getStartAt())
+                        .endAt(request.getEndAt())
+                        .isPrivate(Boolean.TRUE.equals(request.getIsPrivate()))
+                        .build()
+        );
+
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public MyScheduleMarkingResponse getMarkedDates(Long userId, Long teamId, LocalDate from, LocalDate to) {
+        requireMember(teamId, userId);
+
+        if (from == null || to == null) {
+            throw new MyScheduleException(MyScheduleErrorCodes.INVALID_RANGE, "from/to는 필수입니다", 400);
+        }
+        if (to.isBefore(from)) {
+            throw new MyScheduleException(MyScheduleErrorCodes.INVALID_RANGE, "to는 from보다 빠를 수 없습니다", 400);
+        }
+
+        LocalDateTime rangeStart = from.atStartOfDay();
+        LocalDateTime rangeEnd = to.plusDays(1).atStartOfDay();
+
+        List<MySchedule> overlaps = myScheduleRepository.findOverlaps(teamId, userId, rangeStart, rangeEnd);
+
+        Set<LocalDate> days = new HashSet<>();
+        for (MySchedule s : overlaps) {
+            LocalDateTime sStart = max(s.getStartAt(), rangeStart);
+            LocalDateTime sEnd = min(s.getEndAt(), rangeEnd);
+
+            LocalDate startDay = sStart.toLocalDate();
+            LocalDate endDay = sEnd.minusNanos(1).toLocalDate();
+
+            LocalDate cur = startDay;
+            while (!cur.isAfter(endDay)) {
+                if (!cur.isBefore(from) && !cur.isAfter(to)) days.add(cur);
+                cur = cur.plusDays(1);
+            }
+        }
+
+        List<LocalDate> sorted = days.stream().sorted().toList();
+        return new MyScheduleMarkingResponse(sorted);
+    }
+
+    @Transactional
+    public MyScheduleResponse update(Long userId, Long teamId, Long scheduleId, MyScheduleUpdateRequest request) {
+        requireMember(teamId, userId);
+        validateRange(request.getStartAt(), request.getEndAt());
+
+        MySchedule schedule = myScheduleRepository.findByIdAndTeamId(scheduleId, teamId)
+                .orElseThrow(() -> new MyScheduleException(
+                        MyScheduleErrorCodes.SCHEDULE_NOT_FOUND, "일정을 찾을 수 없습니다", 404
+                ));
+
+        requireOwner(schedule, userId);
+
+        schedule.update(
+                request.getTitle(),
+                request.getMemo(),
+                request.getStartAt(),
+                request.getEndAt(),
+                Boolean.TRUE.equals(request.getIsPrivate())
+        );
+
+        return toResponse(schedule);
+    }
+
+    @Transactional
+    public void delete(Long userId, Long teamId, Long scheduleId) {
+        requireMember(teamId, userId);
+
+        MySchedule schedule = myScheduleRepository.findByIdAndTeamId(scheduleId, teamId)
+                .orElseThrow(() -> new MyScheduleException(
+                        MyScheduleErrorCodes.SCHEDULE_NOT_FOUND, "일정을 찾을 수 없습니다", 404
+                ));
+
+        requireOwner(schedule, userId);
+        myScheduleRepository.delete(schedule);
+    }
+
+    // ====== helpers ======
+
+    private void requireMember(Long teamId, Long userId) {
+        if (!teamMemberRepository.existsByTeamIdAndUserId(teamId, userId)) {
+            throw new MyScheduleException(MyScheduleErrorCodes.NOT_A_MEMBER, "팀 멤버만 접근할 수 있습니다", 403);
+        }
+    }
+
+    private void requireOwner(MySchedule schedule, Long userId) {
+        if (!Objects.equals(schedule.getUserId(), userId)) {
+            throw new MyScheduleException(MyScheduleErrorCodes.FORBIDDEN, "본인 소유의 개인 일정만 수정/삭제할 수 있습니다", 403);
+        }
+    }
+
+    private void validateRange(LocalDateTime startAt, LocalDateTime endAt) {
+        if (startAt == null || endAt == null) {
+            throw new MyScheduleException(MyScheduleErrorCodes.INVALID_RANGE, "startAt/endAt은 필수입니다", 400);
+        }
+        if (!endAt.isAfter(startAt)) {
+            throw new MyScheduleException(MyScheduleErrorCodes.INVALID_RANGE, "endAt은 startAt보다 이후여야 합니다", 400);
+        }
+    }
+
+    private MyScheduleResponse toResponse(MySchedule s) {
+        return MyScheduleResponse.builder()
+                .id(s.getId())
+                .teamId(s.getTeamId())
+                .userId(s.getUserId())
+                .title(s.getTitle())
+                .memo(s.getMemo())
+                .startAt(s.getStartAt())
+                .endAt(s.getEndAt())
+                .isPrivate(s.isPrivate())
+                .createdAt(s.getCreatedAt())
+                .updatedAt(s.getUpdatedAt())
+                .build();
+    }
+
+    private LocalDateTime max(LocalDateTime a, LocalDateTime b) {
+        return a.isAfter(b) ? a : b;
+    }
+
+    private LocalDateTime min(LocalDateTime a, LocalDateTime b) {
+        return a.isBefore(b) ? a : b;
+    }
+
+    /**
+     * 지금 기준 Busy/Idle (단일 규칙)
+     * Busy if startAt <= now < endAt
+     */
+    @Transactional(readOnly = true)
+    public MyScheduleNowResponse getNowStatus(Long userId, Long teamId) {
+        requireMember(teamId, userId);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        List<MySchedule> overlaps =
+                myScheduleRepository.findNowOverlaps(teamId, userId, now);
+
+        boolean isBusy = !overlaps.isEmpty();
+
+        List<MyScheduleNowResponse.ScheduleTimeRange> ranges =
+                overlaps.stream()
+                        .map(s -> new MyScheduleNowResponse.ScheduleTimeRange(
+                                s.getId(),
+                                s.getTitle(),
+                                s.getStartAt(),
+                                s.getEndAt()
+                        ))
+                        .toList();
+
+        return new MyScheduleNowResponse(isBusy, ranges);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MyScheduleResponse> getDaySchedules(Long userId, Long teamId, LocalDate date) {
+        requireMember(teamId, userId);
+
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.plusDays(1).atStartOfDay();
+
+        return myScheduleRepository
+                .findOverlaps(teamId, userId, start, end)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,8 +39,8 @@ spring:
   mail:
     host: ${MAIL_HOST:smtp.gmail.com}
     port: ${MAIL_PORT:587}
-    username: ${MAIL_USERNAME:seokhawnkim@gmail.com}
-    password: ${MAIL_PASSWORD:lhpzobtkpfvnstvd}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
     properties:
       mail:
         smtp:
@@ -84,8 +84,8 @@ app:
 
 oauth:
   kakao:
-    client-id: ${KAKAO_CLIENT_ID:f0090451b3aedc13683fc670394f8de8}
-    client-secret: ${KAKAO_CLIENT_SECRET:R9E7xGESxXIk9Q8HVfh2nu8adIUsOpaA}
+    client-id: ${KAKAO_CLIENT_ID:}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/auth/kakao/callback}
     authorize-uri: https://kauth.kakao.com/oauth/authorize
     token-uri: https://kauth.kakao.com/oauth/token


### PR DESCRIPTION
# 📅 개인 일정(My Schedule) API 구현 정리

> **Unimate – 팀 내부 개인 일정 관리**
>
> `allDay` 개념을 제거하고  
> **모든 일정을 시간 기반(startAt / endAt)으로 통일**한 최종 구현 정리 문서입니다.

---

## 1️⃣ 설계 핵심 요약

### ✔️ 일정 모델 규칙
- 모든 일정은 **반드시 시간 범위**를 가짐
- 하루 종일 일정도 아래 규칙으로 표현
  - `startAt = YYYY-MM-DDT00:00`
  - `endAt   = YYYY-MM-(DD+1)T00:00`

### ✔️ Busy / Idle 판단 기준
```text
Busy if  startAt <= now < endAt
Idle if  위 조건을 만족하는 일정이 하나도 없을 때
