### PR TITLE
Feat/#76 : 찌르기 기능 API 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/poke/controller/PokeController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/controller/PokeController.java
@@ -1,0 +1,84 @@
+package com.gdg.unimatebackend.app.poke.controller;
+
+import com.gdg.unimatebackend.app.poke.dto.PokeMessageResponse;
+import com.gdg.unimatebackend.app.poke.dto.PokeRequest;
+import com.gdg.unimatebackend.app.poke.dto.PokeResponse;
+import com.gdg.unimatebackend.app.poke.dto.PokeTargetsResponse;
+import com.gdg.unimatebackend.app.poke.service.PokeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/pokes")
+@Tag(name = "찌르기", description = "팀원 찌르기 API")
+public class PokeController {
+
+    private final PokeService pokeService;
+
+    // =========================
+    // 찌르기 전송 (다건)
+    // =========================
+    @Operation(
+            summary = "찌르기 전송",
+            description = "여러 팀/여러 팀원을 선택한 문구로 찌릅니다. (본인 포함 시 제외 처리)",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "찌르기 처리 완료"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "403", description = "같은 팀원이 아님"),
+            @ApiResponse(responseCode = "404", description = "찌르기 문구 없음")
+    })
+    @PostMapping
+    public ResponseEntity<PokeResponse> sendPokes(
+            Authentication authentication,
+            @Valid @RequestBody PokeRequest request
+    ) {
+        Long senderId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(pokeService.sendPokes(senderId, request));
+    }
+
+    // =========================
+    // 찌르기 대상 조회
+    // =========================
+    @Operation(
+            summary = "찌르기 대상 조회",
+            description = "내가 속한 팀과 각 팀의 팀원 목록을 조회합니다. (본인 제외)",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/targets")
+    public ResponseEntity<PokeTargetsResponse> getTargets(Authentication authentication) {
+        Long me = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(pokeService.getPokeTargets(me));
+    }
+
+    // =========================
+    // 찌르기 문구 조회
+    // =========================
+    @Operation(
+            summary = "찌르기 문구 조회",
+            description = "사용자가 선택할 수 있는 찌르기 문구 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/messages")
+    public ResponseEntity<List<PokeMessageResponse>> getMessages() {
+        return ResponseEntity.ok(pokeService.getPokeMessages());
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeMessageResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeMessageResponse.java
@@ -1,0 +1,20 @@
+package com.gdg.unimatebackend.app.poke.dto;
+
+import com.gdg.unimatebackend.app.poke.entity.PokeMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PokeMessageResponse {
+
+    private Long messageId;
+    private String content;
+
+    public static PokeMessageResponse from(PokeMessage message){
+        return PokeMessageResponse.builder()
+                .messageId(message.getId())
+                .content(message.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeRequest.java
@@ -1,0 +1,21 @@
+package com.gdg.unimatebackend.app.poke.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PokeRequest {
+
+    private Long messageId;
+    private List<Target> targets;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Target {
+        private Long teamId;
+        private Long userId;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeResponse.java
@@ -1,0 +1,23 @@
+package com.gdg.unimatebackend.app.poke.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PokeResponse {
+
+    private int sentCount;
+    private int excludedSelfCount;
+    private List<InvalidTarget> invalidTargets;
+
+    @Getter
+    @Builder
+    public static class InvalidTarget {
+        private Long teamId;
+        private Long userId;
+        private String reason; // NOT_IN_MY_TEAM, NOT_TEAM_MEMBER
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeTargetsResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/dto/PokeTargetsResponse.java
@@ -1,0 +1,29 @@
+package com.gdg.unimatebackend.app.poke.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PokeTargetsResponse {
+
+    private List<TeamSection> teams;
+
+    @Getter
+    @Builder
+    public static class TeamSection {
+        private Long teamId;
+        private String teamName;
+        private List<Member> members;
+    }
+
+    @Getter
+    @Builder
+    public static class Member {
+        private Long userId;
+        private String nickname;
+        private String profileImageUrl;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/entity/Poke.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/entity/Poke.java
@@ -1,0 +1,36 @@
+package com.gdg.unimatebackend.app.poke.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Poke {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //찌르기가 발생한 팀
+    @Column(nullable = false)
+    private Long teamId;
+
+    // 찌른 사람 (본인)
+    @Column(nullable = false)
+    private Long senderId;
+
+    // 찌름 당한 사람 (대상자)
+    @Column(nullable = false)
+    private Long targetUserId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poke_message_id", nullable = false)
+    private PokeMessage pokeMessage;
+
+    @Builder
+    public Poke(Long teamId, Long senderId, Long targetUserId, PokeMessage pokeMessage){
+        this.teamId = teamId;
+        this.senderId = senderId;
+        this.targetUserId = targetUserId;
+        this.pokeMessage = pokeMessage;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/entity/PokeMessage.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/entity/PokeMessage.java
@@ -1,0 +1,25 @@
+package com.gdg.unimatebackend.app.poke.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "poke_messages")
+public class PokeMessage {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public PokeMessage(String content){
+        this.content = content;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/repository/PokeMessageRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/repository/PokeMessageRepository.java
@@ -1,0 +1,11 @@
+package com.gdg.unimatebackend.app.poke.repository;
+
+import com.gdg.unimatebackend.app.poke.entity.PokeMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PokeMessageRepository extends JpaRepository<PokeMessage, Long> {
+    // id ASC 기준으로 항상 같은 순서 보장 (=문구 정렬)
+    List<PokeMessage> findAllByOrderByIdAsc();
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/repository/PokeQueryRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/repository/PokeQueryRepository.java
@@ -1,0 +1,35 @@
+package com.gdg.unimatebackend.app.poke.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PokeQueryRepository {
+
+    private final EntityManager em;
+
+    // 찌르기 대상 조회: 내 팀 + 팀원(본인 제외) >>한번에<<
+    public List<Object[]> findTargetRows(Long me) {
+        return em.createNativeQuery("""
+        SELECT
+          t.id AS team_id,
+          t.name AS team_name,
+          u.id AS user_id,
+          u.nickname AS nickname,
+          u.profile_image_url AS profile_image_url
+        FROM team_member my
+        JOIN teams t ON t.id = my.team_id
+        JOIN team_member tm ON tm.team_id = my.team_id
+        JOIN users u ON u.id = tm.user_id
+        WHERE my.user_id = :me
+          AND tm.user_id <> :me
+        ORDER BY t.id ASC, u.id ASC
+    """)
+                .setParameter("me", me)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/repository/PokeRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/repository/PokeRepository.java
@@ -1,0 +1,7 @@
+package com.gdg.unimatebackend.app.poke.repository;
+
+import com.gdg.unimatebackend.app.poke.entity.Poke;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PokeRepository extends JpaRepository<Poke, Long> {
+}

--- a/src/main/java/com/gdg/unimatebackend/app/poke/service/PokeService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/poke/service/PokeService.java
@@ -1,0 +1,188 @@
+package com.gdg.unimatebackend.app.poke.service;
+
+import com.gdg.unimatebackend.app.poke.dto.PokeMessageResponse;
+import com.gdg.unimatebackend.app.poke.dto.PokeRequest;
+import com.gdg.unimatebackend.app.poke.dto.PokeResponse;
+import com.gdg.unimatebackend.app.poke.dto.PokeTargetsResponse;
+import com.gdg.unimatebackend.app.poke.entity.Poke;
+import com.gdg.unimatebackend.app.poke.entity.PokeMessage;
+import com.gdg.unimatebackend.app.poke.repository.PokeMessageRepository;
+import com.gdg.unimatebackend.app.poke.repository.PokeQueryRepository;
+import com.gdg.unimatebackend.app.poke.repository.PokeRepository;
+import com.gdg.unimatebackend.app.team.repository.TeamMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PokeService {
+    private final PokeRepository pokeRepository;
+    private final PokeMessageRepository pokeMessageRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final PokeQueryRepository pokeQueryRepository;
+
+    // =========================
+    // 찌르기 대상 조회 (/targets)
+    // =========================
+    @Transactional(readOnly = true)
+    public PokeTargetsResponse getPokeTargets(Long me) {
+
+        List<Object[]> rows = pokeQueryRepository.findTargetRows(me);
+
+        Map<Long, String> teamNameMap = new LinkedHashMap<>();
+        Map<Long, List<PokeTargetsResponse.Member>> memberMap = new LinkedHashMap<>();
+
+        for (Object[] row : rows) {
+            Long teamId = ((Number) row[0]).longValue();
+            String teamName = (String) row[1];
+
+            Long userId = ((Number) row[2]).longValue();
+            String nickname = (String) row[3];
+            String profileImageUrl = (String) row[4];
+
+            teamNameMap.putIfAbsent(teamId, teamName);
+
+            memberMap
+                    .computeIfAbsent(teamId, k -> new ArrayList<>())
+                    .add(PokeTargetsResponse.Member.builder()
+                            .userId(userId)
+                            .nickname(nickname)
+                            .profileImageUrl(profileImageUrl)
+                            .build());
+        }
+
+        List<PokeTargetsResponse.TeamSection> teams = new ArrayList<>();
+        for (Long teamId : teamNameMap.keySet()) {
+            teams.add(PokeTargetsResponse.TeamSection.builder()
+                    .teamId(teamId)
+                    .teamName(teamNameMap.get(teamId))
+                    .members(memberMap.getOrDefault(teamId, List.of()))
+                    .build());
+        }
+
+        return PokeTargetsResponse.builder()
+                .teams(teams)
+                .build();
+    }
+
+    // =========================
+    // 찌르기 전송 (다건)
+    // =========================
+    @Transactional
+    public PokeResponse sendPokes(Long senderId, PokeRequest request) {
+
+        if (request.getMessageId() == null) {
+            throw new IllegalArgumentException("messageId는 필수입니다.");
+        }
+        if (request.getTargets() == null || request.getTargets().isEmpty()) {
+            throw new IllegalArgumentException("targets는 비어 있을 수 없습니다.");
+        }
+        if (request.getTargets().size() > 50) {
+            throw new IllegalArgumentException("targets는 최대 50명까지 가능합니다.");
+        }
+
+        // ---- 1) 찌르기 문구 조회 ----
+        PokeMessage pokeMessage = pokeMessageRepository.findById(request.getMessageId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 찌르기 문구입니다."));
+
+        // ---- 2) targets 정리 (null 제거 + dedup + 본인 제외) ----
+        int excludedSelfCount = 0;
+        Map<String, PokeRequest.Target> uniqueTargets = new LinkedHashMap<>();
+
+        for (PokeRequest.Target t : request.getTargets()) {
+            if (t == null || t.getTeamId() == null || t.getUserId() == null) continue;
+
+            if (senderId.equals(t.getUserId())) {
+                excludedSelfCount++;
+                continue; // 본인 제외(추천)
+            }
+
+            String key = t.getTeamId() + ":" + t.getUserId();
+            uniqueTargets.putIfAbsent(key, t);
+        }
+
+        if (uniqueTargets.isEmpty()) {
+            return PokeResponse.builder()
+                    .sentCount(0)
+                    .excludedSelfCount(excludedSelfCount)
+                    .invalidTargets(List.of())
+                    .build();
+        }
+
+        // ---- 3) 검증 + poke 생성 ----
+        // sender가 팀에 속하는지: teamId별 캐싱(쿼리 절약)
+        Map<Long, Boolean> senderInTeamCache = new HashMap<>();
+
+        List<Poke> pokesToSave = new ArrayList<>();
+        List<PokeResponse.InvalidTarget> invalidTargets = new ArrayList<>();
+
+        for (PokeRequest.Target t : uniqueTargets.values()) {
+
+            Long teamId = t.getTeamId();
+            Long targetUserId = t.getUserId();
+
+            // (1) sender가 해당 팀에 속하는지(캐싱)
+            boolean senderInTeam = senderInTeamCache.computeIfAbsent(
+                    teamId,
+                    id -> teamMemberRepository.existsByTeamIdAndUserId(id, senderId)
+            );
+
+            if (!senderInTeam) {
+                invalidTargets.add(PokeResponse.InvalidTarget.builder()
+                        .teamId(teamId)
+                        .userId(targetUserId)
+                        .reason("NOT_IN_MY_TEAM")
+                        .build());
+                continue;
+            }
+
+            // (2) target이 해당 팀 멤버인지
+            boolean targetInTeam = teamMemberRepository.existsByTeamIdAndUserId(teamId, targetUserId);
+
+            if (!targetInTeam) {
+                invalidTargets.add(PokeResponse.InvalidTarget.builder()
+                        .teamId(teamId)
+                        .userId(targetUserId)
+                        .reason("NOT_TEAM_MEMBER")
+                        .build());
+                continue;
+            }
+
+            // (3) 유효 → Poke 생성
+            pokesToSave.add(Poke.builder()
+                    .teamId(teamId)
+                    .senderId(senderId)
+                    .targetUserId(targetUserId)
+                    .pokeMessage(pokeMessage)
+                    .build());
+        }
+
+        if (!pokesToSave.isEmpty()) {
+            pokeRepository.saveAll(pokesToSave);
+        }
+
+        log.info("[POKE] sender={}, sent={}, invalid={}, excludedSelf={}",
+                senderId, pokesToSave.size(), invalidTargets.size(), excludedSelfCount);
+
+        return PokeResponse.builder()
+                .sentCount(pokesToSave.size())
+                .excludedSelfCount(excludedSelfCount)
+                .invalidTargets(invalidTargets)
+                .build();
+    }
+
+    // =========================
+    // 찌르기 문구 조회
+    // =========================
+    @Transactional(readOnly = true)
+    public List<PokeMessageResponse> getPokeMessages() {
+        return pokeMessageRepository.findAllByOrderByIdAsc().stream()
+                .map(PokeMessageResponse::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 찌르기 대상 조회 API (/api/pokes/targets)
- 찌르기 다건 전송 API (/api/pokes)
  - 본인 포함 시 제외 처리
  - 중복 대상 dedup 처리
  - 유효하지 않은 대상 invalidTargets로 반환
- 찌르기 문구 조회 API (/api/pokes/messages)

## 테스트
- Swagger 기반 로컬 테스트 완료
