### PR TITLE
feat/#81:팀일정 api 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/app/schedule/repository/MyScheduleRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/repository/MyScheduleRepository.java
@@ -51,4 +51,18 @@ public interface MyScheduleRepository extends JpaRepository<MySchedule, Long> {
             @Param("userId") Long userId,
             @Param("now") LocalDateTime now
     );
+
+    @Query("""
+    select distinct s.userId
+    from MySchedule s
+    where s.teamId = :teamId
+      and s.userId in :userIds
+      and s.startAt <= :now
+      and s.endAt > :now
+""")
+    List<Long> findBusyUserIdsNow(
+            @Param("teamId") Long teamId,
+            @Param("userIds") List<Long> userIds,
+            @Param("now") LocalDateTime now
+    );
 }

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/controller/TeamMemberBusyNowController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/controller/TeamMemberBusyNowController.java
@@ -1,0 +1,48 @@
+package com.gdg.unimatebackend.app.schedule.team.controller;
+
+import com.gdg.unimatebackend.app.schedule.team.dto.TeamMemberBusyNowResponse;
+import com.gdg.unimatebackend.app.schedule.team.service.TeamMemberBusyNowService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/teams/{teamId}/members")
+@Tag(
+        name = "팀원 상태",
+        description = "팀원 Busy/Idle 상태 조회 API"
+)
+public class TeamMemberBusyNowController {
+
+    private final TeamMemberBusyNowService teamMemberBusyNowService;
+
+    @Operation(
+            summary = "팀원 전체 '지금 기준' Busy 조회",
+            description = """
+                    팀원 리스트에서 "지금 바쁨/한가함" 표시를 위해 사용합니다.
+
+                    ✅ N+1 방지
+                    - 개인일정(/my-schedules/now)을 팀원 수만큼 호출하지 않고,
+                      서버에서 한 번에 계산하여 내려줍니다.
+
+                    ✅ Busy 기준
+                    - startAt <= now < endAt 인 개인일정 존재 여부
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/busy-now")
+    public ResponseEntity<TeamMemberBusyNowResponse> getBusyNow(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamMemberBusyNowService.getBusyNow(userId, teamId));
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/controller/TeamScheduleController.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/controller/TeamScheduleController.java
@@ -1,0 +1,152 @@
+package com.gdg.unimatebackend.app.schedule.team.controller;
+
+import com.gdg.unimatebackend.app.schedule.team.dto.*;
+import com.gdg.unimatebackend.app.schedule.team.service.TeamScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/teams/{teamId}/team-schedules")
+@Tag(
+        name = "팀일정",
+        description = """
+                팀에 공유되는 팀 일정(태스크) API입니다.
+
+                📌 설계 규칙
+                - 모든 일정은 시간 기반(startAt / endAt)으로 관리됩니다.
+                - 하루 종일 일정은 startAt=00:00, endAt=다음날 00:00 형태로 표현합니다.
+                - 기간 겹침(overlap) 규칙: startAt < rangeEnd AND endAt > rangeStart
+                """
+)
+public class TeamScheduleController {
+
+    private final TeamScheduleService teamScheduleService;
+
+    @Operation(
+            summary = "팀 일정 생성",
+            description = """
+                    팀에 공유되는 팀 일정을 생성합니다.
+
+                    ✅ 권한
+                    - 팀 멤버 누구나 생성 가능
+
+                    ✅ 규칙
+                    - startAt/endAt 필수
+                    - endAt은 startAt 이후여야 함
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<TeamScheduleResponse> create(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Valid @RequestBody TeamScheduleCreateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamScheduleService.create(userId, teamId, request));
+    }
+
+    @Operation(
+            summary = "팀 일정 수정",
+            description = """
+                    팀 일정을 수정합니다.
+
+                    ✅ 권한
+                    - 작성자(createdBy) 또는 팀장(LEADER)만 가능
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PutMapping("/{scheduleId}")
+    public ResponseEntity<TeamScheduleResponse> update(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "팀 일정 ID", example = "10")
+            @PathVariable Long scheduleId,
+            @Valid @RequestBody TeamScheduleUpdateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamScheduleService.update(userId, teamId, scheduleId, request));
+    }
+
+    @Operation(
+            summary = "팀 일정 삭제",
+            description = """
+                    팀 일정을 삭제합니다.
+
+                    ✅ 권한
+                    - 작성자(createdBy) 또는 팀장(LEADER)만 가능
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> delete(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "팀 일정 ID", example = "10")
+            @PathVariable Long scheduleId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        teamScheduleService.delete(userId, teamId, scheduleId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "기간 단위 팀 일정 조회",
+            description = """
+                    팀 일정만 기간 단위로 조회합니다.
+                    캘린더 마킹/리스트에 사용합니다.
+
+                    ✅ 파라미터
+                    - from/to: YYYY-MM-DD
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<List<TeamScheduleResponse>> getByRange(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "조회 시작 날짜 (YYYY-MM-DD)", example = "2026-02-01")
+            @RequestParam LocalDate from,
+            @Parameter(description = "조회 종료 날짜 (YYYY-MM-DD)", example = "2026-02-28")
+            @RequestParam LocalDate to
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamScheduleService.getByRange(userId, teamId, from, to));
+    }
+
+    @Operation(
+            summary = "특정 날짜 팀 일정 조회",
+            description = """
+                    특정 날짜에 해당하는 팀 일정 목록을 반환합니다.
+                    (일별 상세 화면용)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/day")
+    public ResponseEntity<List<TeamScheduleResponse>> getByDay(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2026-02-10")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(teamScheduleService.getByDay(userId, teamId, date));
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamMemberBusyNowResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamMemberBusyNowResponse.java
@@ -1,0 +1,20 @@
+package com.gdg.unimatebackend.app.schedule.team.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TeamMemberBusyNowResponse {
+
+    private List<MemberBusy> members;
+
+    @Getter
+    @AllArgsConstructor
+    public static class MemberBusy {
+        private Long userId;
+        private boolean isBusy;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamScheduleCreateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamScheduleCreateRequest.java
@@ -1,0 +1,22 @@
+package com.gdg.unimatebackend.app.schedule.team.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TeamScheduleCreateRequest {
+
+    @NotBlank
+    private String title;
+
+    private String memo;
+
+    @NotNull
+    private LocalDateTime startAt;
+
+    @NotNull
+    private LocalDateTime endAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamScheduleResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamScheduleResponse.java
@@ -1,0 +1,23 @@
+package com.gdg.unimatebackend.app.schedule.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TeamScheduleResponse {
+    private Long id;
+    private Long teamId;
+    private Long createdBy;
+
+    private String title;
+    private String memo;
+
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamScheduleUpdateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/dto/TeamScheduleUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.gdg.unimatebackend.app.schedule.team.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TeamScheduleUpdateRequest {
+
+    @NotBlank
+    private String title;
+
+    private String memo;
+
+    @NotNull
+    private LocalDateTime startAt;
+
+    @NotNull
+    private LocalDateTime endAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/entity/TeamSchedule.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/entity/TeamSchedule.java
@@ -1,0 +1,60 @@
+package com.gdg.unimatebackend.app.schedule.team.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "team_schedule",
+        indexes = {
+                @Index(name = "idx_team_schedule_team", columnList = "team_id"),
+                @Index(name = "idx_team_schedule_start_end", columnList = "start_at, end_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TeamSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="team_id", nullable = false)
+    private Long teamId;
+
+    @Column(name="created_by", nullable = false)
+    private Long createdBy;
+
+    @Column(nullable = false, length = 80)
+    private String title;
+
+    @Column(name="memo", length = 500)
+    private String memo;
+
+    @Column(name="start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name="end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @CreationTimestamp
+    @Column(name="created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name="updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void update(String title, String memo, LocalDateTime startAt, LocalDateTime endAt) {
+        this.title = title;
+        this.memo = memo;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/exception/TeamScheduleErrorCodes.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/exception/TeamScheduleErrorCodes.java
@@ -1,0 +1,10 @@
+package com.gdg.unimatebackend.app.schedule.team.exception;
+
+public final class TeamScheduleErrorCodes {
+    private TeamScheduleErrorCodes() {}
+
+    public static final String NOT_A_MEMBER = "NOT_A_MEMBER";
+    public static final String SCHEDULE_NOT_FOUND = "SCHEDULE_NOT_FOUND";
+    public static final String FORBIDDEN = "FORBIDDEN";
+    public static final String INVALID_RANGE = "INVALID_RANGE";
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/exception/TeamScheduleException.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/exception/TeamScheduleException.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.app.schedule.team.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TeamScheduleException extends RuntimeException {
+    private final String code;
+    private final int status;
+
+    public TeamScheduleException(String code, String message, int status) {
+        super(message);
+        this.code = code;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/repository/TeamScheduleRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/repository/TeamScheduleRepository.java
@@ -1,0 +1,29 @@
+package com.gdg.unimatebackend.app.schedule.team.repository;
+
+import com.gdg.unimatebackend.app.schedule.team.entity.TeamSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamScheduleRepository extends JpaRepository<TeamSchedule, Long> {
+
+    Optional<TeamSchedule> findByIdAndTeamId(Long id, Long teamId);
+
+    @Query("""
+        select s
+        from TeamSchedule s
+        where s.teamId = :teamId
+          and s.startAt < :rangeEnd
+          and s.endAt > :rangeStart
+        order by s.startAt asc
+    """)
+    List<TeamSchedule> findOverlaps(
+            @Param("teamId") Long teamId,
+            @Param("rangeStart") LocalDateTime rangeStart,
+            @Param("rangeEnd") LocalDateTime rangeEnd
+    );
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/service/TeamMemberBusyNowService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/service/TeamMemberBusyNowService.java
@@ -1,0 +1,49 @@
+package com.gdg.unimatebackend.app.schedule.team.service;
+
+import com.gdg.unimatebackend.app.schedule.repository.MyScheduleRepository;
+import com.gdg.unimatebackend.app.schedule.team.dto.TeamMemberBusyNowResponse;
+import com.gdg.unimatebackend.app.schedule.team.exception.TeamScheduleErrorCodes;
+import com.gdg.unimatebackend.app.schedule.team.exception.TeamScheduleException;
+import com.gdg.unimatebackend.app.team.entity.TeamMember;
+import com.gdg.unimatebackend.app.team.repository.TeamMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class TeamMemberBusyNowService {
+
+    private final TeamMemberRepository teamMemberRepository;
+    private final MyScheduleRepository myScheduleRepository;
+
+    @Transactional(readOnly = true)
+    public TeamMemberBusyNowResponse getBusyNow(Long userId, Long teamId) {
+        requireMember(teamId, userId);
+
+        List<TeamMember> members = teamMemberRepository.findAllByTeamIdOrderByJoinedAtAsc(teamId);
+        List<Long> userIds = members.stream().map(TeamMember::getUserId).distinct().toList();
+
+        LocalDateTime now = LocalDateTime.now();
+        List<Long> busyUserIds = myScheduleRepository.findBusyUserIdsNow(teamId, userIds, now);
+
+        Set<Long> busySet = new HashSet<>(busyUserIds);
+
+        List<TeamMemberBusyNowResponse.MemberBusy> result = userIds.stream()
+                .map(uid -> new TeamMemberBusyNowResponse.MemberBusy(uid, busySet.contains(uid)))
+                .toList();
+
+        return new TeamMemberBusyNowResponse(result);
+    }
+
+    private void requireMember(Long teamId, Long userId) {
+        if (!teamMemberRepository.existsByTeamIdAndUserId(teamId, userId)) {
+            throw new TeamScheduleException(TeamScheduleErrorCodes.NOT_A_MEMBER, "팀 멤버만 접근할 수 있습니다", 403);
+        }
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/app/schedule/team/service/TeamScheduleService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/schedule/team/service/TeamScheduleService.java
@@ -1,0 +1,156 @@
+package com.gdg.unimatebackend.app.schedule.team.service;
+
+import com.gdg.unimatebackend.app.schedule.team.dto.*;
+import com.gdg.unimatebackend.app.schedule.team.entity.TeamSchedule;
+import com.gdg.unimatebackend.app.schedule.team.exception.TeamScheduleErrorCodes;
+import com.gdg.unimatebackend.app.schedule.team.exception.TeamScheduleException;
+import com.gdg.unimatebackend.app.schedule.team.repository.TeamScheduleRepository;
+import com.gdg.unimatebackend.app.team.entity.TeamMember;
+import com.gdg.unimatebackend.app.team.entity.TeamRole;
+import com.gdg.unimatebackend.app.team.repository.TeamMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamScheduleService {
+
+    private final TeamScheduleRepository teamScheduleRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    @Transactional
+    public TeamScheduleResponse create(Long userId, Long teamId, TeamScheduleCreateRequest request) {
+        TeamMember me = requireMember(teamId, userId);
+        validateRange(request.getStartAt(), request.getEndAt());
+
+        TeamSchedule saved = teamScheduleRepository.save(
+                TeamSchedule.builder()
+                        .teamId(teamId)
+                        .createdBy(userId)
+                        .title(request.getTitle())
+                        .memo(request.getMemo())
+                        .startAt(request.getStartAt())
+                        .endAt(request.getEndAt())
+                        .build()
+        );
+
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public TeamScheduleResponse update(Long userId, Long teamId, Long scheduleId, TeamScheduleUpdateRequest request) {
+        TeamMember me = requireMember(teamId, userId);
+        validateRange(request.getStartAt(), request.getEndAt());
+
+        TeamSchedule schedule = teamScheduleRepository.findByIdAndTeamId(scheduleId, teamId)
+                .orElseThrow(() -> new TeamScheduleException(
+                        TeamScheduleErrorCodes.SCHEDULE_NOT_FOUND, "일정을 찾을 수 없습니다", 404
+                ));
+
+        requireWriterOrLeader(me, schedule, userId);
+
+        schedule.update(
+                request.getTitle(),
+                request.getMemo(),
+                request.getStartAt(),
+                request.getEndAt()
+        );
+
+        return toResponse(schedule);
+    }
+
+    @Transactional
+    public void delete(Long userId, Long teamId, Long scheduleId) {
+        TeamMember me = requireMember(teamId, userId);
+
+        TeamSchedule schedule = teamScheduleRepository.findByIdAndTeamId(scheduleId, teamId)
+                .orElseThrow(() -> new TeamScheduleException(
+                        TeamScheduleErrorCodes.SCHEDULE_NOT_FOUND, "일정을 찾을 수 없습니다", 404
+                ));
+
+        requireWriterOrLeader(me, schedule, userId);
+
+        teamScheduleRepository.delete(schedule);
+    }
+
+    @Transactional(readOnly = true)
+    public java.util.List<TeamScheduleResponse> getByRange(Long userId, Long teamId, LocalDate from, LocalDate to) {
+        requireMember(teamId, userId);
+
+        if (from == null || to == null) {
+            throw new TeamScheduleException(TeamScheduleErrorCodes.INVALID_RANGE, "from/to는 필수입니다", 400);
+        }
+        if (to.isBefore(from)) {
+            throw new TeamScheduleException(TeamScheduleErrorCodes.INVALID_RANGE, "to는 from보다 빠를 수 없습니다", 400);
+        }
+
+        LocalDateTime rangeStart = from.atStartOfDay();
+        LocalDateTime rangeEnd = to.plusDays(1).atStartOfDay();
+
+        return teamScheduleRepository.findOverlaps(teamId, rangeStart, rangeEnd)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public java.util.List<TeamScheduleResponse> getByDay(Long userId, Long teamId, LocalDate date) {
+        requireMember(teamId, userId);
+
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.plusDays(1).atStartOfDay();
+
+        return teamScheduleRepository.findOverlaps(teamId, start, end)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    // ===== helpers =====
+
+    private TeamMember requireMember(Long teamId, Long userId) {
+        Optional<TeamMember> me = teamMemberRepository.findByTeamIdAndUserId(teamId, userId);
+        if (me.isEmpty()) {
+            throw new TeamScheduleException(TeamScheduleErrorCodes.NOT_A_MEMBER, "팀 멤버만 접근할 수 있습니다", 403);
+        }
+        return me.get();
+    }
+
+    private void requireWriterOrLeader(TeamMember me, TeamSchedule schedule, Long userId) {
+        boolean isWriter = Objects.equals(schedule.getCreatedBy(), userId);
+        boolean isLeader = me.getRole() == TeamRole.LEADER;
+
+        if (!isWriter && !isLeader) {
+            throw new TeamScheduleException(TeamScheduleErrorCodes.FORBIDDEN, "작성자 또는 팀장만 수정/삭제할 수 있습니다", 403);
+        }
+    }
+
+    private void validateRange(LocalDateTime startAt, LocalDateTime endAt) {
+        if (startAt == null || endAt == null) {
+            throw new TeamScheduleException(TeamScheduleErrorCodes.INVALID_RANGE, "startAt/endAt은 필수입니다", 400);
+        }
+        if (!endAt.isAfter(startAt)) {
+            throw new TeamScheduleException(TeamScheduleErrorCodes.INVALID_RANGE, "endAt은 startAt보다 이후여야 합니다", 400);
+        }
+    }
+
+    private TeamScheduleResponse toResponse(TeamSchedule s) {
+        return TeamScheduleResponse.builder()
+                .id(s.getId())
+                .teamId(s.getTeamId())
+                .createdBy(s.getCreatedBy())
+                .title(s.getTitle())
+                .memo(s.getMemo())
+                .startAt(s.getStartAt())
+                .endAt(s.getEndAt())
+                .createdAt(s.getCreatedAt())
+                .updatedAt(s.getUpdatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
# 🗓️ 팀 일정 & 팀원 Busy 조회 API 사용 가이드

이 문서는 **팀 일정 API**와 **팀원 전체 ‘지금 기준’ Busy 조회 API**를  
👉 **백엔드 / 프론트 / QA 모두가 바로 이해하고 테스트할 수 있도록** 정리한 가이드입니다.  
(포스트맨 테스트 기준으로 작성)

---

## 1️⃣ 팀 일정 API 개요

### 📌 팀 일정이란?
- 팀에 **공유되는 일정(태스크)** 입니다.
- 개인 일정과 달리 **모든 팀원이 조회 가능**합니다.
- 시간 기반 일정(`startAt`, `endAt`)만 존재합니다.

### 📌 권한 정책
| 기능 | 권한 |
|----|----|
| 생성 | 팀 멤버 누구나 |
| 수정 | 작성자 또는 팀장 |
| 삭제 | 작성자 또는 팀장 |
| 조회 | 팀 멤버 |

---
✅ 정상 동작 확인 시나리오

팀 일정 생성 (POST)

특정 날짜 조회로 일정 포함 여부 확인

기간 조회로 일정 포함 여부 확인

개인 일정 생성 후 Busy 조회 → isBusy = true

개인 일정 없을 때 Busy 조회 → isBusy = false

5️⃣ 정리 한 줄 요약

팀 일정 → 팀이 공유하는 일정 (조회 가능)

Busy 상태 → 개인 일정 기준, 비공개 포함

팀 일정과 Busy는 완전히 독립적인 개념