### PR TITLE
fix/#86: 팀 생성 및 수정 시 팀시작일과 종료일 설정 필수로 변경

### DIFF
--- a/db/sql/team_period_migration.sql
+++ b/db/sql/team_period_migration.sql
@@ -1,0 +1,13 @@
+-- Step 1: nullable로 컬럼 추가
+alter table teams add column start_at date null;
+alter table teams add column end_at date null;
+
+-- Step 2: 기존 데이터 기본값 채우기 (30일 기준)
+update teams
+set start_at = date(created_at),
+    end_at = date(created_at) + interval 30 day
+where start_at is null or end_at is null;
+
+-- Step 3: not null 제약 적용
+alter table teams modify column start_at date not null;
+alter table teams modify column end_at date not null;

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamCreateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamCreateRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 public class TeamCreateRequest {
 
@@ -18,4 +20,10 @@ public class TeamCreateRequest {
 
     @NotNull
     private TeamColor color;
+
+    @NotNull
+    private LocalDate startAt;
+
+    @NotNull
+    private LocalDate endAt;
 }

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamResponse.java
@@ -1,9 +1,11 @@
 package com.gdg.unimatebackend.app.team.dto;
 
 import com.gdg.unimatebackend.app.team.entity.TeamColor;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -15,6 +17,10 @@ public class TeamResponse {
     private TeamColor color;
     private String colorHex;
     private Long ownerUserId;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    @JsonProperty("isCompleted")
+    private boolean isCompleted;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamSummaryResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamSummaryResponse.java
@@ -2,9 +2,11 @@ package com.gdg.unimatebackend.app.team.dto;
 
 import com.gdg.unimatebackend.app.team.entity.TeamColor;
 import com.gdg.unimatebackend.app.team.entity.TeamRole;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -17,6 +19,10 @@ public class TeamSummaryResponse {
     private String colorHex;
     private TeamRole myRole;
     private long memberCount;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    @JsonProperty("isCompleted")
+    private boolean isCompleted;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamUpdateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/dto/TeamUpdateRequest.java
@@ -3,6 +3,8 @@ package com.gdg.unimatebackend.app.team.dto;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 public class TeamUpdateRequest {
 
@@ -11,4 +13,7 @@ public class TeamUpdateRequest {
 
     @Size(max = 300)
     private String description;
+
+    private LocalDate startAt;
+    private LocalDate endAt;
 }

--- a/src/main/java/com/gdg/unimatebackend/app/team/entity/Team.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/entity/Team.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -34,6 +35,12 @@ public class Team {
     @Column(nullable = false, updatable = false, length = 20)
     private TeamColor color;
 
+    @Column(name = "start_at", nullable = false)
+    private LocalDate startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDate endAt;
+
     @Column(name = "owner_user_id")
     private Long ownerUserId;
 
@@ -61,8 +68,10 @@ public class Team {
         this.inviteCodeExpiresAt = null;
     }
 
-    public void update(String name, String description) {
+    public void update(String name, String description, LocalDate startAt, LocalDate endAt) {
         if (name != null && !name.isBlank()) this.name = name;
         if (description != null) this.description = description;
+        if (startAt != null) this.startAt = startAt;
+        if (endAt != null) this.endAt = endAt;
     }
 }

--- a/src/main/java/com/gdg/unimatebackend/app/team/service/TeamService.java
+++ b/src/main/java/com/gdg/unimatebackend/app/team/service/TeamService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -35,12 +36,15 @@ public class TeamService {
     // ===== 팀 생성 =====
     @Transactional
     public TeamResponse createTeam(Long userId, TeamCreateRequest request) {
+        validateTeamPeriod(request.getStartAt(), request.getEndAt());
 
         Team team = Team.builder()
                 .name(request.getName())
                 .description(request.getDescription())
                 .color(request.getColor()) // 팀 대표색 고정
                 .ownerUserId(userId)
+                .startAt(request.getStartAt())
+                .endAt(request.getEndAt())
                 .build();
 
         team = teamRepository.save(team);
@@ -94,6 +98,9 @@ public class TeamService {
                     .colorHex(myDisplayColor != null ? myDisplayColor.getHex() : null)
                     .myRole(myRole)
                     .memberCount(memberCount)
+                    .startAt(t.getStartAt())
+                    .endAt(t.getEndAt())
+                    .isCompleted(isCompleted(t.getEndAt()))
                     .createdAt(t.getCreatedAt())
                     .updatedAt(t.getUpdatedAt())
                     .build());
@@ -139,7 +146,12 @@ public class TeamService {
         requireLeader(teamId, userId, team);
 
         // 정책: color 변경 불가 (name/description만)
-        team.update(request.getName(), request.getDescription());
+        if (request.getStartAt() != null || request.getEndAt() != null) {
+            LocalDate newStart = (request.getStartAt() != null) ? request.getStartAt() : team.getStartAt();
+            LocalDate newEnd = (request.getEndAt() != null) ? request.getEndAt() : team.getEndAt();
+            validateTeamPeriod(newStart, newEnd);
+        }
+        team.update(request.getName(), request.getDescription(), request.getStartAt(), request.getEndAt());
         return toTeamResponse(team);
     }
 
@@ -371,9 +383,25 @@ public class TeamService {
                 .color(team.getColor())
                 .colorHex(team.getColor() != null ? team.getColor().getHex() : null)
                 .ownerUserId(team.getOwnerUserId())
+                .startAt(team.getStartAt())
+                .endAt(team.getEndAt())
+                .isCompleted(isCompleted(team.getEndAt()))
                 .createdAt(team.getCreatedAt())
                 .updatedAt(team.getUpdatedAt())
                 .build();
+    }
+
+    private void validateTeamPeriod(LocalDate startAt, LocalDate endAt) {
+        if (startAt == null || endAt == null) {
+            throw new TeamException(TeamErrorCodes.FORBIDDEN, "startAt/endAt은 필수입니다", 400);
+        }
+        if (endAt.isBefore(startAt)) {
+            throw new TeamException(TeamErrorCodes.FORBIDDEN, "endAt은 startAt보다 빠를 수 없습니다", 400);
+        }
+    }
+
+    private boolean isCompleted(LocalDate endAt) {
+        return endAt != null && endAt.isBefore(LocalDate.now());
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# PR1 – Team 기간(startAt / endAt) 필드 추가 및 정합성 개선

본 PR은 **UI 요구사항(팀 생성/편집/캘린더 정합)**을 만족시키기 위해  
`Team` 도메인에 **기간(startAt, endAt)** 개념을 도입하고,  
응답/검증/마이그레이션까지 포함한 **1차(MVP) 필수 패치**입니다.

---

## 1. 작업 배경

- 팀 생성/편집 UI에 **팀 작업 기간(시작일/종료일)** 입력이 존재
- 기존 백엔드에는 Team 기간 개념이 없어 UI와 불일치
- 캘린더/홈 화면에서 **진행중 팀 / 완료된 팀** 구분 불가

👉 본 PR에서 Team 기간을 추가하여 UI–백엔드 정합성을 맞춥니다.

---

## 2. 핵심 결정 사항

- **기간 타입**: `LocalDate`
  - 팀플은 날짜 단위가 적합 (시간 단위는 일정/모임에서 처리)
- **완료 판단 기준**
  - `endAt < today` → 완료
  - `endAt == today` → 진행중
- **응답 필드**
  - `startAt`, `endAt`, `isCompleted` 포함
- **검증 정책**
  - `startAt`, `endAt` 필수
  - `endAt < startAt` 허용 ❌ (400 에러)

---

## 3. 변경 파일 목록

### Entity / Service
- `src/main/java/com/gdg/unimatebackend/app/team/entity/Team.java`
- `src/main/java/com/gdg/unimatebackend/app/team/service/TeamService.java`

### DTO
- `src/main/java/com/gdg/unimatebackend/app/team/dto/TeamCreateRequest.java`
- `src/main/java/com/gdg/unimatebackend/app/team/dto/TeamUpdateRequest.java`
- `src/main/java/com/gdg/unimatebackend/app/team/dto/TeamResponse.java`
- `src/main/java/com/gdg/unimatebackend/app/team/dto/TeamSummaryResponse.java`

---
