### PR TITLE
feat/#77: 모이기(일정조율) 기능 API 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/controller/SchedulePollController.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/controller/SchedulePollController.java
@@ -1,0 +1,160 @@
+package com.gdg.unimatebackend.schedulepoll.controller;
+
+import com.gdg.unimatebackend.schedulepoll.dto.*;
+import com.gdg.unimatebackend.schedulepoll.service.SchedulePollQueryService;
+import com.gdg.unimatebackend.schedulepoll.service.SchedulePollService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/schedule-polls")
+@Tag(
+        name = "모이기",
+        description = "팀 회의 시간을 조율하기 위한 모이기(시간 투표) API"
+)
+public class SchedulePollController {
+
+    private final SchedulePollService schedulePollService;
+    private final SchedulePollQueryService schedulePollQueryService;
+
+    @Operation(
+            summary = "모이기 생성",
+            description = """
+                    팀 회의 시간을 조율하기 위한 모이기를 생성합니다.
+                    
+                    - 팀 멤버만 생성 가능합니다.
+                    - 날짜 목록 + 하루 시간 범위를 기준으로 시간 슬롯이 생성됩니다.
+                    - 아직 투표 전 상태이며 status=OPEN 으로 시작합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<SchedulePollCreateResponse> create(
+            Authentication authentication,
+            @Valid @RequestBody SchedulePollCreateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(schedulePollService.create(userId, request));
+    }
+
+    @Operation(
+            summary = "모이기 상세 조회",
+            description = """
+                    모이기 상세 정보를 조회합니다.
+                    
+                    - 팀 멤버만 조회 가능합니다.
+                    - 멤버 목록, 각 멤버의 투표 현황, 내 선택 시간(mySlots)을 포함합니다.
+                    - 모든 팀원이 투표한 경우, 모두 가능한 가장 빠른 시간이 autoFixedSlotId로 계산됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/{pollId}")
+    public ResponseEntity<SchedulePollDetailResponse> getDetail(
+            Authentication authentication,
+            @Parameter(description = "모이기 ID", example = "1")
+            @PathVariable Long pollId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(schedulePollQueryService.getDetail(userId, pollId));
+    }
+
+    @Operation(
+            summary = "내 가능 시간 선택/수정",
+            description = """
+                    내가 가능한 시간 슬롯을 선택하거나 수정합니다.
+                    
+                    - 기존 투표가 있으면 덮어씁니다 (PUT, 멱등).
+                    - 모이기가 확정(locked=true)된 이후에는 수정할 수 없습니다.
+                    - 모든 팀원이 투표 완료 시 자동으로 auto-fixed 시간이 계산됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PutMapping("/{pollId}/votes/me")
+    public ResponseEntity<Void> upsertMyVote(
+            Authentication authentication,
+            @Parameter(description = "모이기 ID", example = "1")
+            @PathVariable Long pollId,
+            @Valid @RequestBody SchedulePollVoteUpsertRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        schedulePollService.upsertMyVote(userId, pollId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "모이기 시간 수동 확정",
+            description = """
+                    모이기 시간을 팀장이 수동으로 확정합니다.
+                    
+                    - 팀장만 가능합니다.
+                    - autoFixedSlotId가 있어도 다른 시간으로 변경할 수 있습니다.
+                    - 확정 후에는 locked=true 상태가 되며, 투표 수정이 불가능합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PatchMapping("/{pollId}/fix")
+    public ResponseEntity<Void> fix(
+            Authentication authentication,
+            @Parameter(description = "모이기 ID", example = "1")
+            @PathVariable Long pollId,
+            @Valid @RequestBody SchedulePollFixRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        schedulePollService.fix(userId, pollId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "모이기 기본 정보 수정",
+            description = """
+                    모이기의 제목/메모/알림 설정을 수정합니다.
+                    
+                    - 팀 멤버만 수정 가능합니다.
+                    - 시간 슬롯 자체는 변경되지 않습니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PutMapping("/{pollId}")
+    public ResponseEntity<Void> updateMeta(
+            Authentication authentication,
+            @Parameter(description = "모이기 ID", example = "1")
+            @PathVariable Long pollId,
+            @Valid @RequestBody SchedulePollMetaUpdateRequest request
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        schedulePollService.updateMeta(userId, pollId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "모이기 삭제",
+            description = """
+                    모이기를 삭제합니다.
+                    
+                    - 팀 멤버만 삭제 가능합니다.
+                    - 삭제 시 투표 정보도 함께 삭제됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{pollId}")
+    public ResponseEntity<Void> delete(
+            Authentication authentication,
+            @Parameter(description = "모이기 ID", example = "1")
+            @PathVariable Long pollId
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        schedulePollService.delete(userId, pollId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/controller/TeamSchedulePollController.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/controller/TeamSchedulePollController.java
@@ -1,0 +1,69 @@
+package com.gdg.unimatebackend.schedulepoll.controller;
+
+import com.gdg.unimatebackend.schedulepoll.dto.TeamFixedSchedulePollSummaryResponse;
+import com.gdg.unimatebackend.schedulepoll.service.SchedulePollQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/teams/{teamId}/schedule-polls")
+@Tag(name = "모이기", description = "팀 회의 시간을 조율하기 위한 모이기(시간 투표) API")
+public class TeamSchedulePollController {
+
+    private final SchedulePollQueryService schedulePollQueryService;
+
+    @Operation(
+            summary = "팀 확정 모이기 목록 조회(기간)",
+            description = """
+                    특정 기간 내에 확정된 모이기 목록을 조회합니다.
+                    - 팀 멤버만 조회 가능합니다.
+                    - 캘린더 '전체' 탭 / 월 마킹용
+                    - 확정된 회의만 반환합니다(AUTO_FIXED / MANUALLY_FIXED)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/fixed")
+    public ResponseEntity<List<TeamFixedSchedulePollSummaryResponse>> fixedRange(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "조회 시작 날짜", example = "2026-02-01")
+            @RequestParam LocalDate from,
+            @Parameter(description = "조회 종료 날짜", example = "2026-02-28")
+            @RequestParam LocalDate to
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(schedulePollQueryService.getTeamFixedRange(userId, teamId, from, to));
+    }
+
+    @Operation(
+            summary = "팀 확정 모이기 목록 조회(하루)",
+            description = """
+                    특정 날짜의 확정된 모이기 목록을 조회합니다.
+                    - 팀 멤버만 조회 가능합니다.
+                    - 캘린더에서 날짜 클릭 시 '전체' 탭에 보여줄 데이터
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/fixed/day")
+    public ResponseEntity<List<TeamFixedSchedulePollSummaryResponse>> fixedDay(
+            Authentication authentication,
+            @Parameter(description = "팀 ID", example = "1")
+            @PathVariable Long teamId,
+            @Parameter(description = "조회 날짜", example = "2026-02-23")
+            @RequestParam LocalDate date
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(schedulePollQueryService.getTeamFixedDay(userId, teamId, date));
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollCreateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollCreateRequest.java
@@ -1,0 +1,26 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulePollCreateRequest {
+    private Long teamId;
+    private List<LocalDate> dates;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String timezone;
+    private Integer slotMinutes; // null이면 기본 30
+    private String title;
+    private String memo;
+    private String alarm;
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollCreateResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollCreateResponse.java
@@ -1,0 +1,14 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulePollCreateResponse {
+    private Long pollId;
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollDetailResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollDetailResponse.java
@@ -1,0 +1,65 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import com.gdg.unimatebackend.schedulepoll.entity.PollStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulePollDetailResponse {
+
+    private Long pollId;
+    private Long teamId;
+    private String timezone;
+    private Integer slotMinutes;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private List<LocalDate> dates;
+
+    private String title;
+    private String memo;
+    private String alarm;
+
+    private PollStatus status;
+    private boolean locked;
+
+    private Integer autoFixedSlotId;
+    private Integer fixedSlotId;
+
+    private long totalCount;
+    private long votedCount;
+
+    private List<MemberDto> members;
+    private List<MemberVoteDto> votesByMember;
+
+    private List<Integer> intersectionSlots;
+    private List<Integer> mySlots;
+
+    private List<SlotDefinitionResponse> slotDefinitions;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberDto {
+        private Long memberId;   // userId
+        private String name;     // nickname
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberVoteDto {
+        private Long memberId;         // userId
+        private List<Integer> slots;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollFixRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollFixRequest.java
@@ -1,0 +1,14 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulePollFixRequest {
+    private Integer fixedSlotId;
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollMetaUpdateRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollMetaUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulePollMetaUpdateRequest {
+    private String title;
+    private String memo;
+    private String alarm;
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollVoteUpsertRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SchedulePollVoteUpsertRequest.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulePollVoteUpsertRequest {
+    private List<Integer> slots;
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SlotDefinitionResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/SlotDefinitionResponse.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class SlotDefinitionResponse {
+    private Integer slotId;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/TeamFixedSchedulePollSummaryResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/dto/TeamFixedSchedulePollSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.gdg.unimatebackend.schedulepoll.dto;
+
+import com.gdg.unimatebackend.schedulepoll.entity.PollStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamFixedSchedulePollSummaryResponse {
+    private Long pollId;
+    private String title;
+    private PollStatus status;
+    private Integer fixedSlotId;
+    private List<LocalDate> dates;
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/PollStatus.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/PollStatus.java
@@ -1,0 +1,7 @@
+package com.gdg.unimatebackend.schedulepoll.entity;
+
+public enum PollStatus {
+    OPEN,
+    AUTO_FIXED,
+    MANUALLY_FIXED
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePoll.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePoll.java
@@ -1,0 +1,90 @@
+package com.gdg.unimatebackend.schedulepoll.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "schedule_polls")
+public class SchedulePoll {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long teamId;
+
+    @Column(nullable = false)
+    private String timezone;
+
+    @Column(nullable = false)
+    private Integer slotMinutes;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+
+    private String title;
+    private String memo;
+    private String alarm;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PollStatus status;
+
+    @Column(nullable = false)
+    private boolean locked;
+
+    private Integer autoFixedSlotId;
+    private Integer fixedSlotId;
+
+    @OneToMany(mappedBy = "schedulePoll", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulePollDate> dates = new ArrayList<>();
+
+    @OneToMany(mappedBy = "schedulePoll", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulePollVote> votes = new ArrayList<>();
+
+    @Builder
+    public SchedulePoll(Long teamId, String timezone, Integer slotMinutes, LocalTime startTime, LocalTime endTime,
+                        String title, String memo, String alarm) {
+        this.teamId = teamId;
+        this.timezone = timezone;
+        this.slotMinutes = slotMinutes;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.title = title;
+        this.memo = memo;
+        this.alarm = alarm;
+        this.status = PollStatus.OPEN;
+        this.locked = false;
+    }
+
+    public void addDate(SchedulePollDate date) {
+        this.dates.add(date);
+        date.setSchedulePoll(this);
+    }
+
+    public void updateMeta(String title, String memo, String alarm) {
+        if (title != null) this.title = title;
+        if (memo != null) this.memo = memo;
+        if (alarm != null) this.alarm = alarm;
+    }
+
+    public void setAutoFixed(Integer slotId) {
+        this.autoFixedSlotId = slotId;
+        this.status = PollStatus.AUTO_FIXED;
+    }
+
+    public void fixManually(Integer fixedSlotId) {
+        this.fixedSlotId = fixedSlotId;
+        this.status = PollStatus.MANUALLY_FIXED;
+        this.locked = true;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePollDate.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePollDate.java
@@ -1,0 +1,33 @@
+package com.gdg.unimatebackend.schedulepoll.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "schedule_poll_dates")
+public class SchedulePollDate {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_poll_id", nullable = false)
+    private SchedulePoll schedulePoll;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    public SchedulePollDate(LocalDate date) {
+        this.date = date;
+    }
+
+    void setSchedulePoll(SchedulePoll schedulePoll) {
+        this.schedulePoll = schedulePoll;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePollVote.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePollVote.java
@@ -1,0 +1,52 @@
+package com.gdg.unimatebackend.schedulepoll.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "schedule_poll_votes",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_poll_voter", columnNames = {"schedule_poll_id", "voter_id"})
+        }
+)
+public class SchedulePollVote {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_poll_id", nullable = false)
+    private SchedulePoll schedulePoll;
+
+    @Column(name = "voter_id", nullable = false)
+    private Long voterId; // ✅ userId
+
+    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulePollVoteSlot> slots = new ArrayList<>();
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public SchedulePollVote(SchedulePoll poll, Long voterId) {
+        this.schedulePoll = poll;
+        this.voterId = voterId;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void replaceSlots(List<Integer> newSlotIds) {
+        this.slots.clear();
+        for (Integer slotId : newSlotIds) {
+            this.slots.add(new SchedulePollVoteSlot(this, slotId));
+        }
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePollVoteSlot.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/entity/SchedulePollVoteSlot.java
@@ -1,0 +1,28 @@
+package com.gdg.unimatebackend.schedulepoll.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "schedule_poll_vote_slots")
+public class SchedulePollVoteSlot {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private SchedulePollVote vote;
+
+    @Column(nullable = false)
+    private Integer slotId;
+
+    public SchedulePollVoteSlot(SchedulePollVote vote, Integer slotId) {
+        this.vote = vote;
+        this.slotId = slotId;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/exception/SchedulePollErrorCodes.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/exception/SchedulePollErrorCodes.java
@@ -1,0 +1,41 @@
+package com.gdg.unimatebackend.schedulepoll.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public final class SchedulePollErrorCodes {
+
+    private SchedulePollErrorCodes() {}
+
+    public static final ErrorCode SCHEDULE_POLL_NOT_FOUND =
+            new ErrorCode(HttpStatus.NOT_FOUND, "SCHEDULE_POLL_404", "모임을 찾을 수 없습니다.");
+
+    public static final ErrorCode FORBIDDEN =
+            new ErrorCode(HttpStatus.FORBIDDEN, "SCHEDULE_POLL_403", "권한이 없습니다.");
+
+    public static final ErrorCode POLL_LOCKED =
+            new ErrorCode(HttpStatus.CONFLICT, "SCHEDULE_POLL_409", "확정된 모임은 변경할 수 없습니다.");
+
+    public static final ErrorCode INVALID_DATE_RANGE =
+            new ErrorCode(HttpStatus.BAD_REQUEST, "SCHEDULE_POLL_400_1", "날짜/시간 범위가 올바르지 않습니다.");
+
+    public static final ErrorCode INVALID_SLOTS =
+            new ErrorCode(HttpStatus.BAD_REQUEST, "SCHEDULE_POLL_400_2", "선택한 슬롯이 올바르지 않습니다.");
+
+    public static final ErrorCode INVALID_REQUEST =
+            new ErrorCode(HttpStatus.BAD_REQUEST, "SCHEDULE_POLL_400_3", "요청이 올바르지 않습니다.");
+
+    @Getter
+    public static class ErrorCode {
+        private final HttpStatus httpStatus;
+        private final String code;
+        private final String message;
+
+        public ErrorCode(HttpStatus httpStatus, String code, String message) {
+            this.httpStatus = httpStatus;
+            this.code = code;
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/exception/SchedulePollException.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/exception/SchedulePollException.java
@@ -1,0 +1,20 @@
+package com.gdg.unimatebackend.schedulepoll.exception;
+
+public class SchedulePollException extends RuntimeException {
+
+    private final SchedulePollErrorCodes.ErrorCode errorCode;
+
+    public SchedulePollException(SchedulePollErrorCodes.ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public SchedulePollException(SchedulePollErrorCodes.ErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
+
+    public SchedulePollErrorCodes.ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/repository/SchedulePollRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/repository/SchedulePollRepository.java
@@ -1,0 +1,54 @@
+package com.gdg.unimatebackend.schedulepoll.repository;
+
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePoll;
+import com.gdg.unimatebackend.schedulepoll.entity.PollStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SchedulePollRepository extends JpaRepository<SchedulePoll, Long> {
+
+    /**
+     * 팀 캘린더(월/기간 마킹)용: "전체(회의)"로 표시할 모이기 목록
+     * - MANUALLY_FIXED: 팀장이 확정한 회의 (locked=true && fixedSlotId != null)
+     * - AUTO_FIXED: 전원 투표 완료로 자동 픽스된 회의 (autoFixedSlotId != null)
+     */
+    @Query("""
+        select distinct p
+        from SchedulePoll p
+        join p.dates d
+        where p.teamId = :teamId
+          and (
+                (p.status = com.gdg.unimatebackend.schedulepoll.entity.PollStatus.MANUALLY_FIXED
+                 and p.locked = true
+                 and p.fixedSlotId is not null)
+             or (p.status = com.gdg.unimatebackend.schedulepoll.entity.PollStatus.AUTO_FIXED
+                 and p.autoFixedSlotId is not null)
+              )
+          and d.date between :from and :to
+        """)
+    List<SchedulePoll> findFixedByTeamIdAndRange(Long teamId, LocalDate from, LocalDate to);
+
+    /**
+     * 팀 캘린더(하루 클릭)용: 해당 날짜의 "전체(회의)" 모이기 목록
+     * - MANUALLY_FIXED / AUTO_FIXED 모두 포함
+     */
+    @Query("""
+        select distinct p
+        from SchedulePoll p
+        join p.dates d
+        where p.teamId = :teamId
+          and (
+                (p.status = com.gdg.unimatebackend.schedulepoll.entity.PollStatus.MANUALLY_FIXED
+                 and p.locked = true
+                 and p.fixedSlotId is not null)
+             or (p.status = com.gdg.unimatebackend.schedulepoll.entity.PollStatus.AUTO_FIXED
+                 and p.autoFixedSlotId is not null)
+              )
+          and d.date = :date
+        """)
+    List<SchedulePoll> findFixedByTeamIdAndDay(Long teamId, LocalDate date);
+}
+

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/repository/SchedulePollVoteRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/repository/SchedulePollVoteRepository.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.schedulepoll.repository;
+
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SchedulePollVoteRepository extends JpaRepository<SchedulePollVote, Long> {
+
+    Optional<SchedulePollVote> findBySchedulePoll_IdAndVoterId(Long pollId, Long voterId);
+
+    List<SchedulePollVote> findAllBySchedulePoll_Id(Long pollId);
+
+    long countBySchedulePoll_Id(Long pollId);
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/repository/SchedulePollVoteSlotRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/repository/SchedulePollVoteSlotRepository.java
@@ -1,0 +1,7 @@
+package com.gdg.unimatebackend.schedulepoll.repository;
+
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollVoteSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SchedulePollVoteSlotRepository extends JpaRepository<SchedulePollVoteSlot, Long> {
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/service/SchedulePollAutoFixService.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/service/SchedulePollAutoFixService.java
@@ -1,0 +1,39 @@
+package com.gdg.unimatebackend.schedulepoll.service;
+
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollVote;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollVoteSlot;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class SchedulePollAutoFixService {
+
+    public List<Integer> computeIntersectionSlots(List<SchedulePollVote> votes, long totalCount) {
+        if (votes == null || votes.isEmpty()) return List.of();
+        if (totalCount <= 0) return List.of();
+
+        Map<Integer, Long> freq = new HashMap<>();
+
+        for (SchedulePollVote vote : votes) {
+            Set<Integer> unique = new HashSet<>();
+            for (SchedulePollVoteSlot s : vote.getSlots()) unique.add(s.getSlotId());
+
+            for (Integer slotId : unique) {
+                freq.put(slotId, freq.getOrDefault(slotId, 0L) + 1L);
+            }
+        }
+
+        List<Integer> intersection = new ArrayList<>();
+        for (Map.Entry<Integer, Long> e : freq.entrySet()) {
+            if (e.getValue() == totalCount) intersection.add(e.getKey());
+        }
+        intersection.sort(Comparator.naturalOrder());
+        return intersection;
+    }
+
+    public Integer pickEarliestSlot(List<Integer> intersectionSlots) {
+        if (intersectionSlots == null || intersectionSlots.isEmpty()) return null;
+        return intersectionSlots.get(0);
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/service/SchedulePollQueryService.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/service/SchedulePollQueryService.java
@@ -1,0 +1,207 @@
+package com.gdg.unimatebackend.schedulepoll.service;
+
+import com.gdg.unimatebackend.schedulepoll.dto.SchedulePollDetailResponse;
+import com.gdg.unimatebackend.schedulepoll.dto.SlotDefinitionResponse;
+import com.gdg.unimatebackend.schedulepoll.dto.TeamFixedSchedulePollSummaryResponse;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePoll;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollDate;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollVote;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollVoteSlot;
+import com.gdg.unimatebackend.schedulepoll.exception.SchedulePollErrorCodes;
+import com.gdg.unimatebackend.schedulepoll.exception.SchedulePollException;
+import com.gdg.unimatebackend.schedulepoll.repository.SchedulePollRepository;
+import com.gdg.unimatebackend.schedulepoll.repository.SchedulePollVoteRepository;
+import com.gdg.unimatebackend.team.dto.TeamMemberResponse;
+import com.gdg.unimatebackend.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class SchedulePollQueryService {
+
+    private final SchedulePollRepository schedulePollRepository;
+    private final SchedulePollVoteRepository voteRepository;
+    private final SchedulePollAutoFixService autoFixService;
+
+    private final TeamService teamService;
+
+    @Transactional(readOnly = true)
+    public SchedulePollDetailResponse getDetail(Long userId, Long pollId) {
+        SchedulePoll poll = schedulePollRepository.findById(pollId)
+                .orElseThrow(() -> new SchedulePollException(SchedulePollErrorCodes.SCHEDULE_POLL_NOT_FOUND));
+
+        List<TeamMemberResponse> members = teamService.getTeamMembers(userId, poll.getTeamId());
+        long totalCount = members.size();
+
+        List<SchedulePollVote> votes = voteRepository.findAllBySchedulePoll_Id(pollId);
+        long votedCount = votes.size();
+
+        List<SchedulePollDetailResponse.MemberVoteDto> votesByMember = votes.stream()
+                .map(v -> SchedulePollDetailResponse.MemberVoteDto.builder()
+                        .memberId(v.getVoterId())
+                        .slots(v.getSlots().stream()
+                                .map(SchedulePollVoteSlot::getSlotId)
+                                .distinct()
+                                .sorted()
+                                .toList())
+                        .build())
+                .toList();
+
+        List<Integer> intersection = autoFixService.computeIntersectionSlots(votes, totalCount);
+
+        List<Integer> mySlots = votes.stream()
+                .filter(v -> Objects.equals(v.getVoterId(), userId))
+                .findFirst()
+                .map(v -> v.getSlots().stream()
+                        .map(SchedulePollVoteSlot::getSlotId)
+                        .distinct()
+                        .sorted()
+                        .toList())
+                .orElse(List.of());
+
+        List<SchedulePollDetailResponse.MemberDto> memberDtos = members.stream()
+                .map(m -> SchedulePollDetailResponse.MemberDto.builder()
+                        .memberId(m.getUserId())
+                        .name(m.getNickname())
+                        .build())
+                .toList();
+
+        // ✅ dates 정렬 + slotDefinitions 생성
+        List<LocalDate> sortedDates = poll.getDates().stream()
+                .map(SchedulePollDate::getDate)
+                .sorted()
+                .toList();
+
+        List<SlotDefinitionResponse> slotDefinitions = buildSlotDefinitions(
+                poll.getSlotMinutes(),
+                poll.getStartTime(),
+                poll.getEndTime(),
+                sortedDates
+        );
+
+        return SchedulePollDetailResponse.builder()
+                .pollId(poll.getId())
+                .teamId(poll.getTeamId())
+                .timezone(poll.getTimezone())
+                .slotMinutes(poll.getSlotMinutes())
+                .startTime(poll.getStartTime())
+                .endTime(poll.getEndTime())
+                .dates(sortedDates)
+                .title(poll.getTitle())
+                .memo(poll.getMemo())
+                .alarm(poll.getAlarm())
+                .status(poll.getStatus())
+                .locked(poll.isLocked())
+                .autoFixedSlotId(poll.getAutoFixedSlotId())
+                .fixedSlotId(poll.getFixedSlotId())
+                .totalCount(totalCount)
+                .votedCount(votedCount)
+                .members(memberDtos)
+                .votesByMember(votesByMember)
+                .intersectionSlots(intersection)
+                .mySlots(mySlots)
+                .slotDefinitions(slotDefinitions) // ✅ 추가
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TeamFixedSchedulePollSummaryResponse> getTeamFixedRange(Long userId, Long teamId, LocalDate from, LocalDate to) {
+        teamService.getTeamMembers(userId, teamId);
+        return schedulePollRepository.findFixedByTeamIdAndRange(teamId, from, to)
+                .stream()
+                .map(this::toSummary)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TeamFixedSchedulePollSummaryResponse> getTeamFixedDay(Long userId, Long teamId, LocalDate date) {
+        teamService.getTeamMembers(userId, teamId);
+        return schedulePollRepository.findFixedByTeamIdAndDay(teamId, date)
+                .stream()
+                .map(this::toSummary)
+                .toList();
+    }
+
+    @Transactional
+    public void recalculateAutoFixIfPossible(Long userId, Long pollId) {
+        SchedulePoll poll = schedulePollRepository.findById(pollId)
+                .orElseThrow(() -> new SchedulePollException(SchedulePollErrorCodes.SCHEDULE_POLL_NOT_FOUND));
+
+        if (poll.isLocked()) return;
+
+        List<TeamMemberResponse> members = teamService.getTeamMembers(userId, poll.getTeamId());
+        long totalCount = members.size();
+        long votedCount = voteRepository.countBySchedulePoll_Id(pollId);
+
+        if (totalCount > 0 && votedCount == totalCount) {
+            List<SchedulePollVote> votes = voteRepository.findAllBySchedulePoll_Id(pollId);
+            List<Integer> intersection = autoFixService.computeIntersectionSlots(votes, totalCount);
+            Integer earliest = autoFixService.pickEarliestSlot(intersection);
+            if (earliest != null) {
+                poll.setAutoFixed(earliest);
+                schedulePollRepository.save(poll);
+            }
+        }
+    }
+
+    private TeamFixedSchedulePollSummaryResponse toSummary(SchedulePoll poll) {
+        return TeamFixedSchedulePollSummaryResponse.builder()
+                .pollId(poll.getId())
+                .title(poll.getTitle())
+                .status(poll.getStatus())
+                .fixedSlotId(poll.getFixedSlotId())
+                .dates(poll.getDates().stream().map(SchedulePollDate::getDate).sorted().toList())
+                .build();
+    }
+
+    /**
+     * ✅ slotId ↔ (date, startTime, endTime) 매핑표 생성
+     *
+     * 규칙:
+     * - dates는 정렬된 리스트를 받는다고 가정
+     * - 각 날짜마다 startTime~endTime을 slotMinutes 단위로 쪼갠다
+     * - slotId는 0부터 순차 증가
+     * - endTime을 넘는 마지막 조각은 만들지 않는다
+     */
+    private List<SlotDefinitionResponse> buildSlotDefinitions(
+            Integer slotMinutes,
+            LocalTime startTime,
+            LocalTime endTime,
+            List<LocalDate> dates
+    ) {
+        if (slotMinutes == null || slotMinutes <= 0 || startTime == null || endTime == null || dates == null) {
+            return List.of();
+        }
+
+        List<SlotDefinitionResponse> defs = new ArrayList<>();
+        int slotId = 0;
+
+        for (LocalDate d : dates) {
+            LocalTime t = startTime;
+            while (t.isBefore(endTime)) {
+                LocalTime next = t.plusMinutes(slotMinutes);
+                if (next.isAfter(endTime)) break;
+
+                defs.add(SlotDefinitionResponse.builder()
+                        .slotId(slotId)
+                        .date(d)
+                        .startTime(t)
+                        .endTime(next)
+                        .build());
+
+                slotId++;
+                t = next;
+            }
+        }
+
+        return defs;
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/schedulepoll/service/SchedulePollService.java
+++ b/src/main/java/com/gdg/unimatebackend/schedulepoll/service/SchedulePollService.java
@@ -1,0 +1,156 @@
+package com.gdg.unimatebackend.schedulepoll.service;
+
+import com.gdg.unimatebackend.schedulepoll.dto.SchedulePollCreateRequest;
+import com.gdg.unimatebackend.schedulepoll.dto.SchedulePollCreateResponse;
+import com.gdg.unimatebackend.schedulepoll.dto.SchedulePollFixRequest;
+import com.gdg.unimatebackend.schedulepoll.dto.SchedulePollMetaUpdateRequest;
+import com.gdg.unimatebackend.schedulepoll.dto.SchedulePollVoteUpsertRequest;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePoll;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollDate;
+import com.gdg.unimatebackend.schedulepoll.entity.SchedulePollVote;
+import com.gdg.unimatebackend.schedulepoll.exception.SchedulePollErrorCodes;
+import com.gdg.unimatebackend.schedulepoll.exception.SchedulePollException;
+import com.gdg.unimatebackend.schedulepoll.repository.SchedulePollRepository;
+import com.gdg.unimatebackend.schedulepoll.repository.SchedulePollVoteRepository;
+import com.gdg.unimatebackend.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class SchedulePollService {
+
+    private final SchedulePollRepository schedulePollRepository;
+    private final SchedulePollVoteRepository voteRepository;
+    private final SchedulePollQueryService queryService;
+
+    // ✅ 추가: 팀 존재/멤버 검증 재사용
+    private final TeamService teamService;
+
+    @Transactional
+    public SchedulePollCreateResponse create(Long userId, SchedulePollCreateRequest req) {
+        // ✅ 팀 존재 + 팀 멤버 검증 (teams/team_member가 비어있으면 여기서 막힘)
+        if (req == null || req.getTeamId() == null) {
+            throw new SchedulePollException(SchedulePollErrorCodes.INVALID_REQUEST);
+        }
+        teamService.getTeamMembers(userId, req.getTeamId());
+
+        validateCreate(req);
+
+        int slotMinutes = (req.getSlotMinutes() == null ? 30 : req.getSlotMinutes());
+
+        SchedulePoll poll = SchedulePoll.builder()
+                .teamId(req.getTeamId())
+                .timezone(req.getTimezone())
+                .slotMinutes(slotMinutes)
+                .startTime(req.getStartTime())
+                .endTime(req.getEndTime())
+                .title(req.getTitle())
+                .memo(req.getMemo())
+                .alarm(req.getAlarm())
+                .build();
+
+        for (var d : req.getDates()) {
+            poll.addDate(new SchedulePollDate(d));
+        }
+
+        SchedulePoll saved = schedulePollRepository.save(poll);
+
+        return SchedulePollCreateResponse.builder()
+                .pollId(saved.getId())
+                .build();
+    }
+
+    @Transactional
+    public void upsertMyVote(Long userId, Long pollId, SchedulePollVoteUpsertRequest req) {
+        SchedulePoll poll = getPollOrThrow(pollId);
+
+        // ✅ 팀 멤버 검증 (poll이 속한 teamId 기준)
+        teamService.getTeamMembers(userId, poll.getTeamId());
+
+        if (poll.isLocked()) throw new SchedulePollException(SchedulePollErrorCodes.POLL_LOCKED);
+
+        if (req == null) throw new SchedulePollException(SchedulePollErrorCodes.INVALID_REQUEST);
+        validateSlots(req.getSlots());
+
+        SchedulePollVote vote = voteRepository.findBySchedulePoll_IdAndVoterId(pollId, userId)
+                .orElseGet(() -> voteRepository.save(new SchedulePollVote(poll, userId)));
+
+        vote.replaceSlots(req.getSlots());
+        voteRepository.save(vote);
+
+        // 투표 후 자동픽스 재계산
+        queryService.recalculateAutoFixIfPossible(userId, pollId);
+    }
+
+    @Transactional
+    public void fix(Long userId, Long pollId, SchedulePollFixRequest req) {
+        SchedulePoll poll = getPollOrThrow(pollId);
+
+        // ✅ 팀 멤버 검증
+        teamService.getTeamMembers(userId, poll.getTeamId());
+
+        if (poll.isLocked()) throw new SchedulePollException(SchedulePollErrorCodes.POLL_LOCKED);
+        if (req == null || req.getFixedSlotId() == null) {
+            throw new SchedulePollException(SchedulePollErrorCodes.INVALID_REQUEST);
+        }
+
+        // TODO(선택): 팀장만 가능 정책이면 여기서 권한 체크 추가
+        poll.fixManually(req.getFixedSlotId());
+        schedulePollRepository.save(poll);
+    }
+
+    @Transactional
+    public void updateMeta(Long userId, Long pollId, SchedulePollMetaUpdateRequest req) {
+        SchedulePoll poll = getPollOrThrow(pollId);
+
+        // ✅ 팀 멤버 검증
+        teamService.getTeamMembers(userId, poll.getTeamId());
+
+        if (req == null) throw new SchedulePollException(SchedulePollErrorCodes.INVALID_REQUEST);
+
+        // TODO(선택): 팀장/생성자만 가능 정책이면 권한 체크 추가
+        poll.updateMeta(req.getTitle(), req.getMemo(), req.getAlarm());
+        schedulePollRepository.save(poll);
+    }
+
+    @Transactional
+    public void delete(Long userId, Long pollId) {
+        SchedulePoll poll = getPollOrThrow(pollId);
+
+        // ✅ 팀 멤버 검증
+        teamService.getTeamMembers(userId, poll.getTeamId());
+
+        // TODO(선택): 팀장/생성자만 가능 정책이면 권한 체크 추가
+        schedulePollRepository.delete(poll);
+    }
+
+    private SchedulePoll getPollOrThrow(Long pollId) {
+        if (pollId == null) throw new SchedulePollException(SchedulePollErrorCodes.INVALID_REQUEST);
+
+        return schedulePollRepository.findById(pollId)
+                .orElseThrow(() -> new SchedulePollException(SchedulePollErrorCodes.SCHEDULE_POLL_NOT_FOUND));
+    }
+
+    private void validateCreate(SchedulePollCreateRequest req) {
+        if (req.getDates() == null || req.getDates().isEmpty()
+                || req.getStartTime() == null || req.getEndTime() == null
+                || req.getTimezone() == null) {
+            throw new SchedulePollException(SchedulePollErrorCodes.INVALID_REQUEST);
+        }
+        if (!req.getStartTime().isBefore(req.getEndTime())) {
+            throw new SchedulePollException(SchedulePollErrorCodes.INVALID_DATE_RANGE);
+        }
+    }
+
+    private void validateSlots(List<Integer> slots) {
+        if (slots == null) throw new SchedulePollException(SchedulePollErrorCodes.INVALID_SLOTS);
+
+        for (Integer s : slots) {
+            if (s == null || s < 0) throw new SchedulePollException(SchedulePollErrorCodes.INVALID_SLOTS);
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 모이기(일정조율) 생성 / 조회 / 수정 / 삭제 API 구현
- 시간 슬롯 기반 투표 및 덮어쓰기(upsert)
- AUTO_FIXED / MANUALLY_FIXED 상태 처리
- 팀 캘린더 연동을 위한 확정 모이기 조회 API 제공
- Swagger 문서 정리 및 중복 API 제거

## 테스트
- Swagger UI를 통해 전 API 로컬 테스트 완료
