### PR TITLE
fix/#44: 개인일정 알림 로직 수정

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/notification/event/MyScheduleAlarmEventListener.java
+++ b/src/main/java/com/gdg/unimatebackend/notification/event/MyScheduleAlarmEventListener.java
@@ -48,6 +48,7 @@ public class MyScheduleAlarmEventListener {
         data.put("teamName", event.getTeamName() != null ? event.getTeamName() : "");
         data.put("teamColorHex", event.getTeamColorHex() != null ? event.getTeamColorHex() : "");
         data.put("myScheduleId", String.valueOf(event.getMyScheduleId()));
+        data.put("alarmType", "ALARM_MINUTES");
         data.put("alarmMinutes", String.valueOf(event.getAlarmMinutes()));
         data.put("messageTitle", event.getMessageTitle());
         data.put("messageBody", event.getMessageBody());

--- a/src/main/java/com/gdg/unimatebackend/notification/event/ScheduleAlarmEventListener.java
+++ b/src/main/java/com/gdg/unimatebackend/notification/event/ScheduleAlarmEventListener.java
@@ -48,6 +48,7 @@ public class ScheduleAlarmEventListener {
         data.put("teamName", event.getTeamName() != null ? event.getTeamName() : "");
         data.put("teamColorHex", event.getTeamColorHex() != null ? event.getTeamColorHex() : "");
         data.put("teamScheduleId", String.valueOf(event.getTeamScheduleId()));
+        data.put("alarmType", "ALARM_MINUTES");
         data.put("alarmMinutes", String.valueOf(event.getAlarmMinutes()));
         data.put("messageTitle", event.getMessageTitle());
         data.put("messageBody", event.getMessageBody());

--- a/src/main/java/com/gdg/unimatebackend/notification/service/MyScheduleAlarmNotificationService.java
+++ b/src/main/java/com/gdg/unimatebackend/notification/service/MyScheduleAlarmNotificationService.java
@@ -74,11 +74,11 @@ public class MyScheduleAlarmNotificationService {
             Long receiverId = s.getUserId();
             if (receiverId == null) continue;
 
-            String eventKey = "MY_SCHEDULE_ALARM:" + s.getId() + ":" + receiverId + ":" + alarmMinutes + ":" + s.getEndAt();
+            String eventKey = "SCHEDULE_ALARM:MY:" + s.getId() + ":" + receiverId + ":" + alarmMinutes + ":" + s.getEndAt();
 
             Notification notification = Notification.builder()
                     .eventKey(eventKey)
-                    .type("MY_SCHEDULE_ALARM")
+                    .type("SCHEDULE_ALARM")
                     .alarmType("ALARM_MINUTES")
                     .teamId(s.getTeamId())
                     .teamName(teamName)


### PR DESCRIPTION
 적용한 변경

  1. 개인 일정 알림도 team 일정과 동일한 type/구조로 정렬
      - type = "SCHEDULE_ALARM"
      - alarmType = "ALARM_MINUTES"
      - eventKey도 "SCHEDULE_ALARM:MY:..." 형태로 통일
  2. 개인 일정 알림 data에 alarmType 추가
      - 프론트 커스텀 알림 조건(alarmType 존재) 만족
