### PR TITLE
feat/#104: 마이페이지 요약 조회 API 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/mypage/controller/MyPageController.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/controller/MyPageController.java
@@ -1,0 +1,36 @@
+package com.gdg.unimatebackend.mypage.controller;
+
+import com.gdg.unimatebackend.mypage.dto.MyPageSummaryResponse;
+import com.gdg.unimatebackend.mypage.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+@Tag(name = "마이페이지", description = "마이페이지 요약 조회 API")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @Operation(
+            summary = "마이페이지 요약 조회",
+            description = """
+                    마이페이지 상단 프로필 + 참여중/완료 팀플 리스트를 조회합니다.
+                    - 참여중/완료 구분은 팀의 isCompleted(endAt < today) 기준입니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<MyPageSummaryResponse> getSummary(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(myPageService.getMyPageSummary(userId));
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/dto/MyPageSummaryResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/dto/MyPageSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.gdg.unimatebackend.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyPageSummaryResponse {
+
+    private MyProfileResponse profile;
+    private List<MyTeamCardResponse> activeTeams;
+    private List<MyTeamCardResponse> completedTeams;
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/dto/MyProfileResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/dto/MyProfileResponse.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyProfileResponse {
+
+    private Long userId;
+    private String nickname;
+    private String email;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/dto/MyTeamCardResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/dto/MyTeamCardResponse.java
@@ -1,0 +1,31 @@
+package com.gdg.unimatebackend.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyTeamCardResponse {
+
+    private Long teamId;
+    private String name;
+    private String description;
+
+    private Long memberCount;
+
+    private LocalDate startAt;
+    private LocalDate endAt;
+
+    private Boolean isCompleted;
+
+    // 팀 카드 스타일용(팀 대표색/내 표시색 등 프로젝트 정책에 맞춰 사용)
+    private String color;     // enum name (ex: GREEN)
+    private String colorHex;  // ex: #AABBCC
+
+    // 와이어프레임의 "마감 D-3" 같은 표시용
+    private String dDay;      // ex: D-3
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/exception/MyPageErrorCodes.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/exception/MyPageErrorCodes.java
@@ -1,0 +1,10 @@
+package com.gdg.unimatebackend.mypage.exception;
+
+public final class MyPageErrorCodes {
+
+    private MyPageErrorCodes() {}
+
+    public static final String UNAUTHORIZED = "MYPAGE_UNAUTHORIZED";
+    public static final String USER_NOT_FOUND = "MYPAGE_USER_NOT_FOUND";
+    public static final String INTERNAL_ERROR = "MYPAGE_INTERNAL_ERROR";
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/exception/MyPageException.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/exception/MyPageException.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.mypage.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MyPageException extends RuntimeException {
+
+  private final String code;
+  private final int status;
+
+  public MyPageException(String code, String message, int status) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/repository/MyPageQueryRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/repository/MyPageQueryRepository.java
@@ -1,0 +1,11 @@
+package com.gdg.unimatebackend.mypage.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MyPageQueryRepository {
+    // 지금 단계에서는 TeamService 재사용으로 충분해서 비워둬도 OK
+    // 추후 "프로필 + 팀 목록 + 팀원수" 같은 걸 한 번에 가져오고 싶으면 여기에 QueryDSL/JPA 커스텀 쿼리 추가
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/service/MyPageAssembler.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/service/MyPageAssembler.java
@@ -1,0 +1,51 @@
+package com.gdg.unimatebackend.mypage.service;
+
+import com.gdg.unimatebackend.mypage.dto.MyProfileResponse;
+import com.gdg.unimatebackend.mypage.dto.MyTeamCardResponse;
+import com.gdg.unimatebackend.team.dto.TeamSummaryResponse;
+import com.gdg.unimatebackend.user.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class MyPageAssembler {
+
+    public MyProfileResponse toProfile(User user) {
+        return MyProfileResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
+    }
+
+    public MyTeamCardResponse toTeamCard(TeamSummaryResponse t) {
+        return MyTeamCardResponse.builder()
+                .teamId(t.getId())
+                .name(t.getName())
+                .description(t.getDescription())
+                .memberCount(t.getMemberCount())
+                .startAt(t.getStartAt())
+                .endAt(t.getEndAt())
+                .isCompleted(t.isCompleted())
+                .color(t.getColor() != null ? t.getColor().name() : null)
+                .colorHex(t.getColorHex())
+                .dDay(calcDDay(t.getEndAt(), t.isCompleted()))
+                .build();
+    }
+
+    private String calcDDay(LocalDate endAt, boolean isCompleted) {
+        if (endAt == null || isCompleted) {
+            return null;
+        }
+
+        long diff = ChronoUnit.DAYS.between(LocalDate.now(), endAt);
+
+        if (diff >= 0) {
+            return "D-" + diff;
+        }
+        return "D+" + Math.abs(diff);
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/mypage/service/MyPageService.java
+++ b/src/main/java/com/gdg/unimatebackend/mypage/service/MyPageService.java
@@ -1,0 +1,68 @@
+package com.gdg.unimatebackend.mypage.service;
+
+import com.gdg.unimatebackend.mypage.dto.MyPageSummaryResponse;
+import com.gdg.unimatebackend.mypage.dto.MyProfileResponse;
+import com.gdg.unimatebackend.mypage.dto.MyTeamCardResponse;
+import com.gdg.unimatebackend.mypage.exception.MyPageErrorCodes;
+import com.gdg.unimatebackend.mypage.exception.MyPageException;
+import com.gdg.unimatebackend.team.dto.TeamSummaryResponse;
+import com.gdg.unimatebackend.team.service.TeamService;
+import com.gdg.unimatebackend.user.entity.User;
+import com.gdg.unimatebackend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final TeamService teamService;
+    private final MyPageAssembler myPageAssembler;
+
+    @Transactional(readOnly = true)
+    public MyPageSummaryResponse getMyPageSummary(Long userId) {
+        if (userId == null) {
+            throw new MyPageException(
+                    MyPageErrorCodes.UNAUTHORIZED,
+                    "인증 정보가 없습니다",
+                    401
+            );
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new MyPageException(
+                        MyPageErrorCodes.USER_NOT_FOUND,
+                        "사용자를 찾을 수 없습니다",
+                        404
+                ));
+
+        // 팀 요약 목록 (teams 도메인 API 재사용)
+        List<TeamSummaryResponse> myTeams = teamService.getMyTeams(userId);
+
+        List<MyTeamCardResponse> activeTeams = new ArrayList<>();
+        List<MyTeamCardResponse> completedTeams = new ArrayList<>();
+
+        for (TeamSummaryResponse t : myTeams) {
+            MyTeamCardResponse card = myPageAssembler.toTeamCard(t);
+
+            if (t.isCompleted()) {
+                completedTeams.add(card);
+            } else {
+                activeTeams.add(card);
+            }
+        }
+
+        MyProfileResponse profile = myPageAssembler.toProfile(user);
+
+        return MyPageSummaryResponse.builder()
+                .profile(profile)
+                .activeTeams(activeTeams)
+                .completedTeams(completedTeams)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 구현 내용
- 마이페이지 요약 조회 API(`/api/mypage`) 구현
- 사용자 프로필 정보 조회
- 참여 중인 팀플 / 완료된 팀플 분리 반환
- 팀스페이스 API(`TeamService.getMyTeams`) 재사용 구조로 구현
- 팀 마감일 기준 D-Day 계산 로직 추가

## 🧪 테스트
- Swagger를 통한 마이페이지 조회 테스트
- 팀 생성 후 마이페이지 참여 중 팀플 반영 확인
- 팀 정보 수정 시 마이페이지 목록 반영 확인
- 초대코드 참여 후 마이페이지 팀 목록 갱신 확인

## 📝 참고 사항
- 마이페이지는 조회/조합 책임만 가지도록 구현
- 마이페이지 전용 엔티티 없이 기존 도메인(User/Team) 재사용
