### PR TITLE
feat/#106: 캘린더 API 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/calendar/controller/CalendarController.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/controller/CalendarController.java
@@ -1,0 +1,57 @@
+package com.gdg.unimatebackend.calendar.controller;
+
+import com.gdg.unimatebackend.calendar.dto.CalendarDayRequest;
+import com.gdg.unimatebackend.calendar.dto.CalendarDayResponse;
+import com.gdg.unimatebackend.calendar.dto.CalendarMonthRequest;
+import com.gdg.unimatebackend.calendar.dto.CalendarMonthResponse;
+import com.gdg.unimatebackend.calendar.service.CalendarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/calendar")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    @GetMapping("/month")
+    public ResponseEntity<CalendarMonthResponse> getMonth(
+            Authentication authentication,
+            @RequestParam String month,                    // YYYY-MM
+            @RequestParam(required = false) List<Long> teamIds,
+            @RequestParam boolean includeMyPersonal
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+
+        CalendarMonthRequest request = CalendarMonthRequest.builder()
+                .month(month)
+                .teamIds(teamIds)
+                .includeMyPersonal(includeMyPersonal)
+                .build();
+
+        return ResponseEntity.ok(calendarService.getMonth(userId, request));
+    }
+
+    @GetMapping("/day")
+    public ResponseEntity<CalendarDayResponse> getDay(
+            Authentication authentication,
+            @RequestParam String date,                     // YYYY-MM-DD
+            @RequestParam(required = false) List<Long> teamIds,
+            @RequestParam boolean includeMyPersonal
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+
+        CalendarDayRequest request = CalendarDayRequest.builder()
+                .date(date)
+                .teamIds(teamIds)
+                .includeMyPersonal(includeMyPersonal)
+                .build();
+
+        return ResponseEntity.ok(calendarService.getDay(userId, request));
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarDayCountResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarDayCountResponse.java
@@ -1,0 +1,12 @@
+package com.gdg.unimatebackend.calendar.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarDayCountResponse {
+    private String date; // YYYY-MM-DD
+    private int count;
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarDayRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarDayRequest.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.calendar.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarDayRequest {
+    private String date;               // YYYY-MM-DD
+    private List<Long> teamIds;        // 없으면 "내가 속한 팀 전체"
+    private boolean includeMyPersonal; // 내 개인 일정 포함 여부
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarDayResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarDayResponse.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.calendar.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarDayResponse {
+    private String date;
+    private List<TeamScheduleGroupResponse> teamSchedules;
+    private List<CalendarItemResponse> personalSchedules;
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarItemResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarItemResponse.java
@@ -1,0 +1,23 @@
+package com.gdg.unimatebackend.calendar.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarItemResponse {
+
+    private Long scheduleId;
+    private String type;      // "TEAM" | "PERSONAL"
+
+    private Long teamId;      // TEAM일 때만
+    private String teamName;  // TEAM일 때만
+
+    private String title;     // 타인 비공개면 null
+    private String startAt;   // ISO String
+    private String endAt;     // ISO String
+
+    private Boolean isCompleted; // 팀 일정이면 사용 가능, 개인일정은 null이어도 됨
+    private boolean isMasked;    // 타인 비공개 개인일정 마스킹 여부
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarMonthRequest.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarMonthRequest.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.calendar.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarMonthRequest {
+    private String month;              // YYYY-MM
+    private List<Long> teamIds;        // 없으면 "내가 속한 팀 전체"
+    private boolean includeMyPersonal; // 내 개인 일정 포함 여부
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarMonthResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/dto/CalendarMonthResponse.java
@@ -1,0 +1,14 @@
+package com.gdg.unimatebackend.calendar.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarMonthResponse {
+    private String month;
+    private List<CalendarDayCountResponse> dayCounts;
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/dto/TeamScheduleGroupResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/dto/TeamScheduleGroupResponse.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.calendar.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamScheduleGroupResponse {
+    private Long teamId;
+    private String teamName;
+    private List<CalendarItemResponse> schedules;
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/exception/CalendarErrorCodes.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/exception/CalendarErrorCodes.java
@@ -1,0 +1,18 @@
+package com.gdg.unimatebackend.calendar.exception;
+
+public final class CalendarErrorCodes {
+
+    private CalendarErrorCodes() {}
+
+    public static final String INVALID_MONTH_FORMAT =
+            "month 형식이 올바르지 않습니다. (예: 2026-02)";
+
+    public static final String INVALID_DATE_FORMAT =
+            "date 형식이 올바르지 않습니다. (예: 2026-02-10)";
+
+    public static final String NO_ACCESSIBLE_TEAM =
+            "조회 가능한 팀이 없습니다.";
+
+    public static final String FORBIDDEN_TEAM_ACCESS =
+            "해당 팀에 접근 권한이 없습니다.";
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/exception/CalendarException.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/exception/CalendarException.java
@@ -1,0 +1,8 @@
+package com.gdg.unimatebackend.calendar.exception;
+
+public class CalendarException extends IllegalArgumentException {
+
+    public CalendarException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/repository/PersonalScheduleRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/repository/PersonalScheduleRepository.java
@@ -1,0 +1,43 @@
+package com.gdg.unimatebackend.calendar.repository;
+
+import com.gdg.unimatebackend.schedule.entity.MySchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+public interface PersonalScheduleRepository extends JpaRepository<MySchedule, Long> {
+
+    @Query("""
+        select s
+        from MySchedule s
+        where s.userId = :userId
+          and s.teamId in :teamIds
+          and s.startAt < :to
+          and s.endAt > :from
+    """)
+    List<MySchedule> findMyOverlappingByTeamIds(
+            @Param("userId") Long userId,
+            @Param("teamIds") List<Long> teamIds,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
+
+    @Query("""
+        select s
+        from MySchedule s
+        where s.userId in :userIds
+          and s.teamId in :teamIds
+          and s.startAt < :to
+          and s.endAt > :from
+    """)
+    List<MySchedule> findAllOverlappingByUserIdsAndTeamIds(
+            @Param("userIds") Set<Long> userIds,
+            @Param("teamIds") List<Long> teamIds,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/service/CalendarService.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/service/CalendarService.java
@@ -1,0 +1,271 @@
+package com.gdg.unimatebackend.calendar.service;
+
+import com.gdg.unimatebackend.calendar.dto.*;
+import com.gdg.unimatebackend.calendar.exception.CalendarErrorCodes;
+import com.gdg.unimatebackend.calendar.exception.CalendarException;
+import com.gdg.unimatebackend.calendar.repository.PersonalScheduleRepository;
+import com.gdg.unimatebackend.schedule.dto.MyScheduleResponse;
+import com.gdg.unimatebackend.schedule.entity.MySchedule;
+import com.gdg.unimatebackend.schedule.service.MyScheduleService;
+import com.gdg.unimatebackend.schedule.team.dto.TeamScheduleResponse;
+import com.gdg.unimatebackend.schedule.team.service.TeamScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+
+    private final CalendarTeamPort calendarTeamPort;
+    private final TeamScheduleService teamScheduleService;
+    private final MyScheduleService myScheduleService; // day 조회에서 내 일정 가져올 때 사용
+    private final PersonalScheduleRepository personalScheduleRepository;
+
+    private static final DateTimeFormatter MONTH_FMT = DateTimeFormatter.ofPattern("yyyy-MM");
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public CalendarMonthResponse getMonth(Long userId, CalendarMonthRequest request) {
+        YearMonth ym;
+        try {
+            ym = YearMonth.parse(request.getMonth(), MONTH_FMT);
+        } catch (Exception e) {
+            throw new CalendarException(CalendarErrorCodes.INVALID_MONTH_FORMAT);
+        }
+
+        LocalDate first = ym.atDay(1);
+        LocalDate last = ym.atEndOfMonth();
+
+        LocalDateTime from = first.atStartOfDay();
+        LocalDateTime to = last.plusDays(1).atStartOfDay(); // [from, to)
+
+        List<Long> teamIds = resolveTeamIds(userId, request.getTeamIds());
+        if (teamIds == null || teamIds.isEmpty()) {
+            throw new CalendarException(CalendarErrorCodes.NO_ACCESSIBLE_TEAM);
+        }
+
+        // 권한/유효 팀 체크 + 팀명 매핑
+        Map<Long, String> teamNames = calendarTeamPort.getTeamNames(userId, teamIds);
+        if (teamNames.size() != teamIds.size()) {
+            throw new CalendarException(CalendarErrorCodes.FORBIDDEN_TEAM_ACCESS);
+        }
+
+        Map<LocalDate, Integer> countMap = new HashMap<>();
+
+        // 1) 팀 일정 카운트 (기간)
+        for (Long teamId : teamIds) {
+            List<TeamScheduleResponse> teamSchedules =
+                    teamScheduleService.getByRange(userId, teamId, first, last);
+
+            if (teamSchedules == null || teamSchedules.isEmpty()) continue;
+
+            for (TeamScheduleResponse s : teamSchedules) {
+                addCountsByOverlap(countMap, s.getStartAt(), s.getEndAt(), first, last);
+            }
+        }
+
+        // 2) 내 개인 일정 카운트 (includeMyPersonal=true) ✅ 최적화: DB 1번
+        if (request.isIncludeMyPersonal()) {
+            List<MySchedule> mySchedules =
+                    personalScheduleRepository.findMyOverlappingByTeamIds(userId, teamIds, from, to);
+
+            for (MySchedule s : mySchedules) {
+                addCountsByOverlap(countMap, s.getStartAt(), s.getEndAt(), first, last);
+            }
+        }
+
+        // 3) 팀원 개인 일정 카운트 ✅ teamIds 필터 포함
+        Set<Long> memberUserIds = calendarTeamPort.getTeamMemberUserIds(userId, teamIds);
+        memberUserIds.remove(userId);
+
+        if (!memberUserIds.isEmpty()) {
+            List<MySchedule> memberSchedules =
+                    personalScheduleRepository.findAllOverlappingByUserIdsAndTeamIds(memberUserIds, teamIds, from, to);
+
+            for (MySchedule s : memberSchedules) {
+                // 비공개여도 블록 1개로 카운트 포함
+                addCountsByOverlap(countMap, s.getStartAt(), s.getEndAt(), first, last);
+            }
+        }
+
+        List<CalendarDayCountResponse> dayCounts = countMap.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> CalendarDayCountResponse.builder()
+                        .date(e.getKey().format(DATE_FMT))
+                        .count(e.getValue())
+                        .build())
+                .toList();
+
+        return CalendarMonthResponse.builder()
+                .month(request.getMonth())
+                .dayCounts(dayCounts)
+                .build();
+    }
+
+    public CalendarDayResponse getDay(Long userId, CalendarDayRequest request) {
+        LocalDate date;
+        try {
+            date = LocalDate.parse(request.getDate(), DATE_FMT);
+        } catch (Exception e) {
+            throw new CalendarException(CalendarErrorCodes.INVALID_DATE_FORMAT);
+        }
+
+        List<Long> teamIds = resolveTeamIds(userId, request.getTeamIds());
+        if (teamIds == null || teamIds.isEmpty()) {
+            throw new CalendarException(CalendarErrorCodes.NO_ACCESSIBLE_TEAM);
+        }
+
+        Map<Long, String> teamNames = calendarTeamPort.getTeamNames(userId, teamIds);
+        if (teamNames.size() != teamIds.size()) {
+            throw new CalendarException(CalendarErrorCodes.FORBIDDEN_TEAM_ACCESS);
+        }
+
+        // 1) 팀 일정(일별): 팀별 그룹핑
+        List<TeamScheduleGroupResponse> teamGroups = new ArrayList<>();
+
+        for (Long teamId : teamIds) {
+            List<TeamScheduleResponse> teamSchedules =
+                    teamScheduleService.getByDay(userId, teamId, date);
+
+            if (teamSchedules == null || teamSchedules.isEmpty()) continue;
+
+            List<CalendarItemResponse> items = new ArrayList<>();
+            for (TeamScheduleResponse s : teamSchedules) {
+                items.add(CalendarItemResponse.builder()
+                        .scheduleId(s.getId())
+                        .type("TEAM")
+                        .teamId(teamId)
+                        .teamName(teamNames.get(teamId))
+                        .title(s.getTitle())
+                        .startAt(toStringSafe(s.getStartAt()))
+                        .endAt(toStringSafe(s.getEndAt()))
+                        .isCompleted(null) // TeamScheduleResponse에 완료 필드 없음
+                        .isMasked(false)
+                        .build());
+            }
+
+            teamGroups.add(TeamScheduleGroupResponse.builder()
+                    .teamId(teamId)
+                    .teamName(teamNames.get(teamId))
+                    .schedules(items)
+                    .build());
+        }
+
+        // 2) 개인 일정 리스트 (내 것 옵션 + 타인 마스킹)
+        List<CalendarItemResponse> personalItems = new ArrayList<>();
+
+        // 2-1) 내 개인 일정 (day에서는 기존 서비스 그대로 사용해도 충분히 빠름)
+        if (request.isIncludeMyPersonal()) {
+            for (Long teamId : teamIds) {
+                List<MyScheduleResponse> myDaySchedules =
+                        myScheduleService.getDaySchedules(userId, teamId, date);
+
+                if (myDaySchedules == null || myDaySchedules.isEmpty()) continue;
+
+                for (MyScheduleResponse s : myDaySchedules) {
+                    personalItems.add(CalendarItemResponse.builder()
+                            .scheduleId(s.getId())
+                            .type("PERSONAL")
+                            .title(s.getTitle())
+                            .startAt(toStringSafe(s.getStartAt()))
+                            .endAt(toStringSafe(s.getEndAt()))
+                            .isCompleted(null)
+                            .isMasked(false)
+                            .build());
+                }
+            }
+        }
+
+        // 2-2) 타인 개인 일정(DB) ✅ teamIds 필터 포함
+        Set<Long> memberUserIds = calendarTeamPort.getTeamMemberUserIds(userId, teamIds);
+        memberUserIds.remove(userId);
+
+        if (!memberUserIds.isEmpty()) {
+            LocalDateTime startOfDay = date.atStartOfDay();
+            LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();
+
+            List<MySchedule> memberSchedules =
+                    personalScheduleRepository.findAllOverlappingByUserIdsAndTeamIds(memberUserIds, teamIds, startOfDay, endOfDay);
+
+            for (MySchedule s : memberSchedules) {
+                boolean masked = s.isPrivate();
+
+                personalItems.add(CalendarItemResponse.builder()
+                        .scheduleId(s.getId())
+                        .type("PERSONAL")
+                        .title(masked ? null : s.getTitle())
+                        .startAt(toStringSafe(s.getStartAt()))
+                        .endAt(toStringSafe(s.getEndAt()))
+                        .isCompleted(null)
+                        .isMasked(masked)
+                        .build());
+            }
+        }
+
+        // 보기 좋게 정렬(시작 시간 순) - ISO string이라 문자열 정렬도 시간 정렬과 동일
+        personalItems.sort(Comparator.comparing(CalendarItemResponse::getStartAt, Comparator.nullsLast(String::compareTo)));
+
+        return CalendarDayResponse.builder()
+                .date(request.getDate())
+                .teamSchedules(teamGroups)
+                .personalSchedules(personalItems)
+                .build();
+    }
+
+    private List<Long> resolveTeamIds(Long userId, List<Long> teamIds) {
+        if (teamIds == null || teamIds.isEmpty()) {
+            return calendarTeamPort.getMyTeamIds(userId);
+        }
+        return teamIds;
+    }
+
+    /**
+     * 일정이 여러 날에 걸치면, 겹치는 모든 날짜에 +1
+     * overlap 기준: startAt < dayEnd AND endAt > dayStart
+     *
+     * 하루종일: 00:00 ~ 다음날 00:00
+     * endAt이 00:00이면 해당 날짜는 미포함 보정
+     */
+    private void addCountsByOverlap(
+            Map<LocalDate, Integer> countMap,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            LocalDate monthStart,
+            LocalDate monthEnd
+    ) {
+        if (startAt == null || endAt == null) return;
+
+        LocalDateTime rangeStart = monthStart.atStartOfDay();
+        LocalDateTime rangeEnd = monthEnd.plusDays(1).atStartOfDay();
+
+        // 월 범위와 겹치지 않으면 컷
+        if (!(startAt.isBefore(rangeEnd) && endAt.isAfter(rangeStart))) return;
+
+        LocalDate startDate = startAt.toLocalDate();
+        LocalDate endDate = endAt.toLocalDate();
+
+        // endAt이 00:00이면 해당 날짜는 미포함 보정
+        if (endAt.toLocalTime().equals(LocalTime.MIDNIGHT)) {
+            endDate = endDate.minusDays(1);
+        }
+
+        if (startDate.isBefore(monthStart)) startDate = monthStart;
+        if (endDate.isAfter(monthEnd)) endDate = monthEnd;
+
+        for (LocalDate d = startDate; !d.isAfter(endDate); d = d.plusDays(1)) {
+            LocalDateTime dayStart = d.atStartOfDay();
+            LocalDateTime dayEnd = d.plusDays(1).atStartOfDay();
+
+            if (startAt.isBefore(dayEnd) && endAt.isAfter(dayStart)) {
+                countMap.merge(d, 1, Integer::sum);
+            }
+        }
+    }
+
+    private static String toStringSafe(LocalDateTime dt) {
+        return dt == null ? null : dt.toString();
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/service/CalendarTeamPort.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/service/CalendarTeamPort.java
@@ -1,0 +1,14 @@
+package com.gdg.unimatebackend.calendar.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface CalendarTeamPort {
+
+    List<Long> getMyTeamIds(Long userId);
+
+    Map<Long, String> getTeamNames(Long userId, List<Long> teamIds);
+
+    Set<Long> getTeamMemberUserIds(Long userId, List<Long> teamIds);
+}

--- a/src/main/java/com/gdg/unimatebackend/calendar/service/CalendarTeamPortImpl.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/service/CalendarTeamPortImpl.java
@@ -1,0 +1,55 @@
+package com.gdg.unimatebackend.calendar.service;
+
+import com.gdg.unimatebackend.team.dto.TeamMemberResponse;
+import com.gdg.unimatebackend.team.dto.TeamSummaryResponse;
+import com.gdg.unimatebackend.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarTeamPortImpl implements CalendarTeamPort {
+
+    private final TeamService teamService;
+
+    @Override
+    public List<Long> getMyTeamIds(Long userId) {
+        List<TeamSummaryResponse> myTeams = teamService.getMyTeams(userId);
+
+        List<Long> teamIds = new ArrayList<>();
+        for (TeamSummaryResponse t : myTeams) {
+            teamIds.add(t.getId()); // ✅ teamId가 아니라 id
+        }
+        return teamIds;
+    }
+
+    @Override
+    public Map<Long, String> getTeamNames(Long userId, List<Long> teamIds) {
+        List<TeamSummaryResponse> myTeams = teamService.getMyTeams(userId);
+
+        Set<Long> want = new HashSet<>(teamIds);
+        Map<Long, String> map = new HashMap<>();
+
+        for (TeamSummaryResponse t : myTeams) {
+            if (want.contains(t.getId())) {     // ✅ id
+                map.put(t.getId(), t.getName());
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public Set<Long> getTeamMemberUserIds(Long userId, List<Long> teamIds) {
+        Set<Long> userIds = new HashSet<>();
+
+        for (Long teamId : teamIds) {
+            List<TeamMemberResponse> members = teamService.getTeamMembers(userId, teamId);
+            for (TeamMemberResponse m : members) {
+                userIds.add(m.getUserId());
+            }
+        }
+        return userIds;
+    }
+}


### PR DESCRIPTION
## 📌 구현 내용

### 1️⃣ 캘린더 월 조회 API 구현
- GET /api/calendar/month
- 월 단위 일정 개수(dayCounts) 반환
- 팀 일정 + 개인 일정 통합 카운트
- includeMyPersonal 옵션 적용
  - true → 내 개인 일정 포함
  - false → 내 개인 일정 제외

### 2️⃣ 캘린더 일 조회 API 구현
- GET /api/calendar/day
- 특정 날짜의 팀 일정 / 개인 일정 목록 반환
- 팀 일정은 팀별 그룹핑하여 반환

### 3️⃣ 개인 일정 토글 기능 구현
- includeMyPersonal=true → 내 개인 일정 포함
- includeMyPersonal=false → 내 개인 일정 제외

### 4️⃣ 팀원 개인 일정 공개/비공개 처리
- isPrivate=false → 제목 그대로 반환
- isPrivate=true → title=null, masked=true 처리

### 5️⃣ 월 조회 성능 최적화
- 기존: 31일 반복 호출 방식
- 개선: DB 기간 조회 기반 카운트 계산
- 불필요한 반복 호출 제거

---

## 🧪 테스트 결과

### ✅ includeMyPersonal=false
- 2026-02-11 → count=3 확인

### ✅ includeMyPersonal=true
- 2026-02-11 → count=4 확인

### ✅ 비공개 일정 마스킹
- title=null
- masked=true 정상 동작 확인

---

## 🔍 변경 범위
- calendar 패키지 추가
- PersonalScheduleRepository 쿼리 추가
- CalendarService 구현
- DTO 추가

---

## ✅ PR 체크 사항
- [x] CI 통과 확인
- [x] conflict 없음
- [x] 월/일 조회 정상 동작 확인
- [x] 개인 일정 토글 동작 확인
- [x] 비공개 일정 마스킹 확인
