### PR TITLE
docs/#106: 캘린더 Swagger 한글 설명 추가

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/calendar/controller/CalendarController.java
+++ b/src/main/java/com/gdg/unimatebackend/calendar/controller/CalendarController.java
@@ -5,6 +5,10 @@ import com.gdg.unimatebackend.calendar.dto.CalendarDayResponse;
 import com.gdg.unimatebackend.calendar.dto.CalendarMonthRequest;
 import com.gdg.unimatebackend.calendar.dto.CalendarMonthResponse;
 import com.gdg.unimatebackend.calendar.service.CalendarService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -15,15 +19,36 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/calendar")
+@Tag(
+        name = "캘린더",
+        description = "팀 일정 및 개인 일정을 월/일 단위로 조회하는 캘린더 API"
+)
 public class CalendarController {
 
     private final CalendarService calendarService;
 
+    @Operation(
+            summary = "월 단위 일정 개수 조회",
+            description = """
+                    월 단위로 날짜별 일정 개수(dayCounts)를 반환합니다.
+
+                    - 팀 일정 + 개인 일정(옵션에 따라 내 일정 포함)을 합산합니다.
+                    - 팀원 개인 일정은 비공개여도 블록 1개로 카운트됩니다.
+                    - teamIds 미전달 시, 내가 속한 모든 팀 기준으로 집계합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
     @GetMapping("/month")
     public ResponseEntity<CalendarMonthResponse> getMonth(
             Authentication authentication,
-            @RequestParam String month,                    // YYYY-MM
+
+            @Parameter(description = "조회 월 (YYYY-MM)", example = "2026-02")
+            @RequestParam String month,
+
+            @Parameter(description = "조회할 팀 ID 목록 (미전달 시 전체 팀 기준)", example = "1")
             @RequestParam(required = false) List<Long> teamIds,
+
+            @Parameter(description = "내 개인 일정 포함 여부", example = "true")
             @RequestParam boolean includeMyPersonal
     ) {
         Long userId = (Long) authentication.getPrincipal();
@@ -37,11 +62,29 @@ public class CalendarController {
         return ResponseEntity.ok(calendarService.getMonth(userId, request));
     }
 
+    @Operation(
+            summary = "특정 날짜 일정 목록 조회",
+            description = """
+                    특정 날짜의 팀 일정 및 개인 일정 목록을 반환합니다.
+
+                    - teamSchedules: 팀별로 그룹핑된 팀 일정 목록
+                    - personalSchedules: 개인 일정 목록
+                    - includeMyPersonal=false 인 경우 내 개인 일정은 제외됩니다.
+                    - 팀원 개인 일정이 비공개(isPrivate=true)인 경우 title=null, masked=true로 반환됩니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
     @GetMapping("/day")
     public ResponseEntity<CalendarDayResponse> getDay(
             Authentication authentication,
-            @RequestParam String date,                     // YYYY-MM-DD
+
+            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2026-02-11")
+            @RequestParam String date,
+
+            @Parameter(description = "조회할 팀 ID 목록 (미전달 시 전체 팀 기준)", example = "1")
             @RequestParam(required = false) List<Long> teamIds,
+
+            @Parameter(description = "내 개인 일정 포함 여부", example = "true")
             @RequestParam boolean includeMyPersonal
     ) {
         Long userId = (Long) authentication.getPrincipal();


### PR DESCRIPTION
## 📌 변경 내용

- 캘린더 API Swagger 문서 한글화
  - @Tag 한글 설명 추가
  - @Operation summary/description 한글화
  - 파라미터 설명 및 예시(example) 추가
  - includeMyPersonal 옵션 동작 설명 보완

기능 로직 변경은 없으며, 문서 가독성 개선 목적의 수정입니다.

---

## 🔍 변경 범위

- CalendarController Swagger 어노테이션 추가/수정

---

## 🧪 영향 범위

- API 동작 변경 없음
- DB 스키마 변경 없음
- 서비스 로직 변경 없음

---

## ✅ PR 체크 사항

- [x] 기능 로직 변경 없음
- [x] Swagger UI 정상 출력 확인
- [x] 기존 캘린더 API 정상 동작 확인
- [x] CI 통과 확인
