### PR TITLE
Feat/#108: 홈 화면 요약 API 구현

### DIFF
--- a/src/main/java/com/gdg/unimatebackend/home/controller/HomeController.java
+++ b/src/main/java/com/gdg/unimatebackend/home/controller/HomeController.java
@@ -1,0 +1,61 @@
+package com.gdg.unimatebackend.home.controller;
+
+import com.gdg.unimatebackend.home.dto.HomeSummaryResponse;
+import com.gdg.unimatebackend.home.service.HomeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import java.util.Arrays;
+import java.util.List;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+@Tag(name = "홈", description = "홈 화면(주간 캘린더/오늘의 일/팀스페이스/알림 뱃지) API")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @Operation(
+            summary = "홈 화면 요약 조회",
+            description = """
+                    홈 화면에 필요한 데이터를 한 번에 조회합니다.
+                    - 주간 캘린더(일~토): 날짜별 일정 개수 포함
+                    - 오늘의 일: 팀 일정 + 내 개인 일정
+                    - 나의 팀 스페이스 목록
+                    - 알림 뱃지(현재는 FCM 토큰만 존재하여 unreadCount는 0으로 반환)
+                    
+                    📌 주간 캘린더 일정 개수(count) 규칙:
+                    - 팀 일정: 카운트 포함
+                    - 내 개인 일정: includeMyPersonal=true 일 때 카운트 포함
+                    - 타인 개인 일정: 홈 화면에서는 카운트에 포함하지 않음
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<HomeSummaryResponse> getHomeSummary(
+            Authentication authentication,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date,
+
+            @RequestParam(required = false)
+            Long[] teamIds,
+
+            @RequestParam(required = false, defaultValue = "true")
+            boolean includeMyPersonal
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+
+        List<Long> teamIdList = (teamIds == null) ? null : Arrays.asList(teamIds);
+
+        return ResponseEntity.ok(homeService.getHomeSummary(userId, date, teamIdList, includeMyPersonal));
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/HomeSummaryResponse.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/HomeSummaryResponse.java
@@ -1,0 +1,23 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class HomeSummaryResponse {
+    private final LocalDate date;
+    private final LocalDate weekStart;
+    private final LocalDate weekEnd;
+
+    private final List<WeeklyCalendarDayDto> weeklyCalendar;
+
+    private final TodaySchedulesDto todaySchedules;
+
+    private final List<MyTeamSpaceDto> myTeamSpaces;
+
+    private final NotificationBadgeDto notification;
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/MyTeamSpaceDto.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/MyTeamSpaceDto.java
@@ -1,0 +1,13 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyTeamSpaceDto {
+    private final Long teamId;
+    private final String teamName;
+    private final String teamColor;
+    private final String teamProfileImageUrl; // 추가
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/NotificationBadgeDto.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/NotificationBadgeDto.java
@@ -1,0 +1,11 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationBadgeDto {
+    private final boolean hasUnread;
+    private final int unreadCount;
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/PersonalScheduleItemDto.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/PersonalScheduleItemDto.java
@@ -1,0 +1,17 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PersonalScheduleItemDto {
+    private final Long teamId;
+    private final Long scheduleId;
+    private final String title;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+    private final boolean isPrivate;
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/ScheduleItemDto.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/ScheduleItemDto.java
@@ -1,0 +1,15 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ScheduleItemDto {
+    private final Long scheduleId;
+    private final String title;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/TeamTodaySchedulesDto.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/TeamTodaySchedulesDto.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TeamTodaySchedulesDto {
+    private final Long teamId;
+    private final String teamName;
+    private final String teamColor; // TeamColor enum name()
+
+    private final List<ScheduleItemDto> schedules;
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/TodaySchedulesDto.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/TodaySchedulesDto.java
@@ -1,0 +1,13 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TodaySchedulesDto {
+    private final List<TeamTodaySchedulesDto> teamSchedules;
+    private final List<PersonalScheduleItemDto> personalSchedules;
+}

--- a/src/main/java/com/gdg/unimatebackend/home/dto/WeeklyCalendarDayDto.java
+++ b/src/main/java/com/gdg/unimatebackend/home/dto/WeeklyCalendarDayDto.java
@@ -1,0 +1,14 @@
+package com.gdg.unimatebackend.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class WeeklyCalendarDayDto {
+    private final LocalDate date;
+    private final boolean isToday;
+    private final int scheduleCount;
+}

--- a/src/main/java/com/gdg/unimatebackend/home/exception/HomeErrorCodes.java
+++ b/src/main/java/com/gdg/unimatebackend/home/exception/HomeErrorCodes.java
@@ -1,0 +1,17 @@
+package com.gdg.unimatebackend.home.exception;
+
+import org.springframework.http.HttpStatus;
+
+public final class HomeErrorCodes {
+    private HomeErrorCodes() {}
+
+    public static final String HOME_ERROR = "HOME_400_000";
+
+    public static HttpStatus statusOf(String code) {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    public static String messageOf(String code) {
+        return "Home API 요청 처리 중 오류가 발생했습니다.";
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/home/exception/HomeException.java
+++ b/src/main/java/com/gdg/unimatebackend/home/exception/HomeException.java
@@ -1,0 +1,17 @@
+package com.gdg.unimatebackend.home.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class HomeException extends RuntimeException {
+
+    private final String code;
+    private final HttpStatus status;
+
+    public HomeException(String code) {
+        super(HomeErrorCodes.messageOf(code));
+        this.code = code;
+        this.status = HomeErrorCodes.statusOf(code);
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/home/repository/HomeQueryRepository.java
+++ b/src/main/java/com/gdg/unimatebackend/home/repository/HomeQueryRepository.java
@@ -1,0 +1,10 @@
+package com.gdg.unimatebackend.home.repository;
+
+import com.gdg.unimatebackend.home.dto.HomeSummaryResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface HomeQueryRepository {
+    HomeSummaryResponse fetchHomeSummary(Long userId, LocalDate date, List<Long> teamIds, boolean includeMyPersonal);
+}

--- a/src/main/java/com/gdg/unimatebackend/home/repository/HomeQueryRepositoryImpl.java
+++ b/src/main/java/com/gdg/unimatebackend/home/repository/HomeQueryRepositoryImpl.java
@@ -1,0 +1,425 @@
+package com.gdg.unimatebackend.home.repository;
+
+import com.gdg.unimatebackend.home.dto.*;
+import com.gdg.unimatebackend.notification.repository.NotificationReceiptRepository;
+import com.gdg.unimatebackend.notification.entity.NotificationReceipt;
+import com.gdg.unimatebackend.schedule.entity.MySchedule;
+import com.gdg.unimatebackend.schedule.repository.MyScheduleRepository;
+import com.gdg.unimatebackend.schedule.team.entity.TeamSchedule;
+import com.gdg.unimatebackend.schedule.team.repository.TeamScheduleRepository;
+import com.gdg.unimatebackend.team.entity.Team;
+import com.gdg.unimatebackend.team.entity.TeamMember;
+import com.gdg.unimatebackend.team.repository.TeamMemberRepository;
+import com.gdg.unimatebackend.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class HomeQueryRepositoryImpl implements HomeQueryRepository {
+
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamRepository teamRepository;
+    private final TeamScheduleRepository teamScheduleRepository;
+    private final MyScheduleRepository myScheduleRepository;
+    private final NotificationReceiptRepository notificationReceiptRepository;
+
+    @Override
+    public HomeSummaryResponse fetchHomeSummary(
+            Long userId,
+            LocalDate date,
+            List<Long> teamIds,
+            boolean includeMyPersonal
+    ) {
+
+        LocalDate baseDate = (date == null) ? LocalDate.now() : date;
+
+        LocalDate weekStart =
+                baseDate.minusDays(baseDate.getDayOfWeek().getValue() % 7);
+
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        List<Long> resolvedTeamIds =
+                resolveTeamIds(userId, teamIds);
+
+        List<WeeklyCalendarDayDto> weeklyCalendar =
+                buildWeeklyCalendarCounts(
+                        userId,
+                        weekStart,
+                        weekEnd,
+                        resolvedTeamIds,
+                        includeMyPersonal
+                );
+
+        List<TeamTodaySchedulesDto> teamTodaySchedules =
+                fetchTeamTodaySchedules(baseDate, resolvedTeamIds);
+
+        List<PersonalScheduleItemDto> personalToday =
+                includeMyPersonal
+                        ? fetchMyPersonalTodaySchedules(
+                        userId,
+                        baseDate,
+                        resolvedTeamIds
+                )
+                        : Collections.emptyList();
+
+        TodaySchedulesDto todaySchedules =
+                TodaySchedulesDto.builder()
+                        .teamSchedules(teamTodaySchedules)
+                        .personalSchedules(personalToday)
+                        .build();
+
+        List<MyTeamSpaceDto> myTeamSpaces =
+                fetchMyTeamSpaces(resolvedTeamIds);
+
+// 기존 repository 메서드 사용해서 unread 존재 여부 계산
+        List<NotificationReceipt> receipts =
+                notificationReceiptRepository.findAllByUserIdWithNotification(userId);
+
+        boolean hasUnread =
+                receipts.stream()
+                        .anyMatch(r -> !r.isRead());
+
+        NotificationBadgeDto notification =
+                NotificationBadgeDto.builder()
+                        .hasUnread(hasUnread)
+                        .unreadCount(0)
+                        .build();
+
+        return HomeSummaryResponse.builder()
+                .date(baseDate)
+                .weekStart(weekStart)
+                .weekEnd(weekEnd)
+                .weeklyCalendar(weeklyCalendar)
+                .todaySchedules(todaySchedules)
+                .myTeamSpaces(myTeamSpaces)
+                .notification(notification)
+                .build();
+    }
+
+    /**
+     * teamIds가 없으면 내가 속한 팀 목록 조회
+     */
+    private List<Long> resolveTeamIds(
+            Long userId,
+            List<Long> teamIds
+    ) {
+
+        List<Long> myTeamIds =
+                teamMemberRepository
+                        .findAllByUserIdOrderByJoinedAtDesc(userId)
+                        .stream()
+                        .map(TeamMember::getTeamId)
+                        .distinct()
+                        .collect(Collectors.toList());
+
+        if (teamIds == null || teamIds.isEmpty()) {
+            return myTeamIds;
+        }
+
+        // 교집합만 허용 (보안 강화)
+        return teamIds.stream()
+                .filter(myTeamIds::contains)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 주간 캘린더 날짜별 count 계산
+     */
+    private List<WeeklyCalendarDayDto> buildWeeklyCalendarCounts(
+            Long userId,
+            LocalDate weekStart,
+            LocalDate weekEnd,
+            List<Long> teamIds,
+            boolean includeMyPersonal
+    ) {
+
+        List<LocalDate> dates = new ArrayList<>();
+
+        for (int i = 0; i < 7; i++) {
+            dates.add(weekStart.plusDays(i));
+        }
+
+        Map<LocalDate, Integer> countMap = new HashMap<>();
+
+        for (LocalDate d : dates) {
+            countMap.put(d, 0);
+        }
+
+        if (!teamIds.isEmpty()) {
+
+            LocalDateTime rangeStart =
+                    weekStart.atStartOfDay();
+
+            LocalDateTime rangeEnd =
+                    weekEnd.plusDays(1).atStartOfDay();
+
+            for (Long teamId : teamIds) {
+
+                // 팀 일정 count
+                List<TeamSchedule> teamSchedules =
+                        teamScheduleRepository.findOverlaps(
+                                teamId,
+                                rangeStart,
+                                rangeEnd
+                        );
+
+                for (TeamSchedule s : teamSchedules) {
+
+                    LocalDate start =
+                            s.getStartAt().toLocalDate();
+
+                    LocalDate end =
+                            s.getEndAt().toLocalDate();
+
+                    LocalDate clampedStart =
+                            start.isBefore(weekStart)
+                                    ? weekStart
+                                    : start;
+
+                    LocalDate clampedEnd =
+                            end.isAfter(weekEnd)
+                                    ? weekEnd
+                                    : end;
+
+                    if (clampedEnd.isBefore(clampedStart))
+                        continue;
+
+                    LocalDate cur = clampedStart;
+
+                    while (!cur.isAfter(clampedEnd)) {
+
+                        countMap.put(
+                                cur,
+                                countMap.get(cur) + 1
+                        );
+
+                        cur = cur.plusDays(1);
+                    }
+                }
+
+                // 개인 일정 count
+                if (includeMyPersonal) {
+
+                    List<MySchedule> mySchedules =
+                            myScheduleRepository.findOverlaps(
+                                    teamId,
+                                    userId,
+                                    rangeStart,
+                                    rangeEnd
+                            );
+
+                    for (MySchedule s : mySchedules) {
+
+                        LocalDate start =
+                                s.getStartAt().toLocalDate();
+
+                        LocalDate end =
+                                s.getEndAt().toLocalDate();
+
+                        LocalDate clampedStart =
+                                start.isBefore(weekStart)
+                                        ? weekStart
+                                        : start;
+
+                        LocalDate clampedEnd =
+                                end.isAfter(weekEnd)
+                                        ? weekEnd
+                                        : end;
+
+                        if (clampedEnd.isBefore(clampedStart))
+                            continue;
+
+                        LocalDate cur = clampedStart;
+
+                        while (!cur.isAfter(clampedEnd)) {
+
+                            countMap.put(
+                                    cur,
+                                    countMap.get(cur) + 1
+                            );
+
+                            cur = cur.plusDays(1);
+                        }
+                    }
+                }
+            }
+        }
+
+        LocalDate today = LocalDate.now();
+
+        return dates.stream()
+                .map(d ->
+                        WeeklyCalendarDayDto.builder()
+                                .date(d)
+                                .isToday(d.equals(today))
+                                .scheduleCount(countMap.get(d))
+                                .build()
+                )
+                .collect(Collectors.toList());
+    }
+
+    private List<TeamTodaySchedulesDto> fetchTeamTodaySchedules(
+            LocalDate date,
+            List<Long> teamIds
+    ) {
+
+        if (teamIds.isEmpty())
+            return Collections.emptyList();
+
+        LocalDateTime rangeStart =
+                date.atStartOfDay();
+
+        LocalDateTime rangeEnd =
+                date.plusDays(1).atStartOfDay();
+
+        Map<Long, Team> teamMap =
+                teamRepository.findAllById(teamIds)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                Team::getId,
+                                t -> t
+                        ));
+
+        List<TeamTodaySchedulesDto> result =
+                new ArrayList<>();
+
+        for (Long teamId : teamIds) {
+
+            Team team = teamMap.get(teamId);
+
+            if (team == null)
+                continue;
+
+            List<TeamSchedule> schedules =
+                    teamScheduleRepository.findOverlaps(
+                            teamId,
+                            rangeStart,
+                            rangeEnd
+                    );
+
+            if (schedules.isEmpty())
+                continue;
+
+            List<ScheduleItemDto> items =
+                    schedules.stream()
+                            .sorted(Comparator.comparing(
+                                    TeamSchedule::getStartAt
+                            ))
+                            .map(s ->
+                                    ScheduleItemDto.builder()
+                                            .scheduleId(s.getId())
+                                            .title(s.getTitle())
+                                            .startAt(s.getStartAt())
+                                            .endAt(s.getEndAt())
+                                            .build()
+                            )
+                            .collect(Collectors.toList());
+
+            result.add(
+                    TeamTodaySchedulesDto.builder()
+                            .teamId(teamId)
+                            .teamName(team.getName())
+                            .teamColor(team.getColor().getHex())
+                            .schedules(items)
+                            .build()
+            );
+        }
+
+        result.sort(
+                Comparator.comparing(
+                        TeamTodaySchedulesDto::getTeamName,
+                        Comparator.nullsLast(String::compareTo)
+                )
+        );
+
+        return result;
+    }
+
+    private List<PersonalScheduleItemDto> fetchMyPersonalTodaySchedules(
+            Long userId,
+            LocalDate date,
+            List<Long> teamIds
+    ) {
+
+        if (teamIds.isEmpty())
+            return Collections.emptyList();
+
+        LocalDateTime rangeStart =
+                date.atStartOfDay();
+
+        LocalDateTime rangeEnd =
+                date.plusDays(1).atStartOfDay();
+
+        List<PersonalScheduleItemDto> result =
+                new ArrayList<>();
+
+        for (Long teamId : teamIds) {
+
+            List<MySchedule> schedules =
+                    myScheduleRepository.findOverlaps(
+                            teamId,
+                            userId,
+                            rangeStart,
+                            rangeEnd
+                    );
+
+            for (MySchedule s : schedules) {
+
+                result.add(
+                        PersonalScheduleItemDto.builder()
+                                .teamId(s.getTeamId())
+                                .scheduleId(s.getId())
+                                .title(s.getTitle())
+                                .startAt(s.getStartAt())
+                                .endAt(s.getEndAt())
+                                .isPrivate(s.isPrivate())
+                                .build()
+                );
+            }
+        }
+
+        result.sort(
+                Comparator.comparing(
+                        PersonalScheduleItemDto::getStartAt,
+                        Comparator.nullsLast(
+                                Comparator.naturalOrder()
+                        )
+                )
+        );
+
+        return result;
+    }
+
+    private List<MyTeamSpaceDto> fetchMyTeamSpaces(
+            List<Long> teamIds
+    ) {
+
+        if (teamIds.isEmpty())
+            return Collections.emptyList();
+
+        return teamRepository.findAllById(teamIds)
+                .stream()
+                .map(t ->
+                        MyTeamSpaceDto.builder()
+                                .teamId(t.getId())
+                                .teamName(t.getName())
+                                .teamColor(t.getColor().getHex())
+                                .build()
+                )
+                .sorted(
+                        Comparator.comparing(
+                                MyTeamSpaceDto::getTeamName,
+                                Comparator.nullsLast(String::compareTo)
+                        )
+                )
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/gdg/unimatebackend/home/service/HomeService.java
+++ b/src/main/java/com/gdg/unimatebackend/home/service/HomeService.java
@@ -1,0 +1,16 @@
+package com.gdg.unimatebackend.home.service;
+
+import com.gdg.unimatebackend.home.dto.HomeSummaryResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface HomeService {
+
+    HomeSummaryResponse getHomeSummary(
+            Long userId,
+            LocalDate date,
+            List<Long> teamIds,
+            boolean includeMyPersonal
+    );
+}

--- a/src/main/java/com/gdg/unimatebackend/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/gdg/unimatebackend/home/service/HomeServiceImpl.java
@@ -1,0 +1,21 @@
+package com.gdg.unimatebackend.home.service;
+
+import com.gdg.unimatebackend.home.dto.HomeSummaryResponse;
+import com.gdg.unimatebackend.home.repository.HomeQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HomeServiceImpl implements HomeService {
+
+    private final HomeQueryRepository homeQueryRepository;
+
+    @Override
+    public HomeSummaryResponse getHomeSummary(Long userId, LocalDate date, List<Long> teamIds, boolean includeMyPersonal) {
+        return homeQueryRepository.fetchHomeSummary(userId, date, teamIds, includeMyPersonal);
+    }
+}


### PR DESCRIPTION
📌 구현 내용

1️⃣ 홈 화면 요약 조회 API 구현  
GET /api/home  

홈 화면에 필요한 데이터를 한 번에 조회할 수 있도록 구현  

- 주간 캘린더 (일 ~ 토)
  - 날짜별 일정 개수(scheduleCount) 반환
  - 팀 일정 + 내 개인 일정 count 포함
  - 멀티데이 일정(startAt ~ endAt) 기간 전체 count 반영
  - 오늘 날짜(today) 여부 반환

- 오늘의 일정 조회
  - 팀 일정: 팀별 그룹핑하여 반환
  - 개인 일정: includeMyPersonal=true일 경우만 반환
  - startAt 기준 정렬 적용

- 나의 팀 스페이스 조회
  - 사용자가 속한 팀 목록 반환
  - teamId, teamName, teamColor, teamProfileImageUrl 포함

- 알림 뱃지 조회
  - NotificationReceiptRepository를 사용하여 읽지 않은 알림 존재 여부(hasUnread) 반환
  - unreadCount는 홈 화면에서 사용하지 않아 0으로 반환


2️⃣ teamIds 파라미터 처리 구현

- teamIds 미입력 시
  → 사용자가 속한 전체 팀 조회

- teamIds 입력 시
  → 사용자가 속한 팀과의 교집합만 조회 (보안 강화)


3️⃣ 개인 일정 포함 옵션 구현

includeMyPersonal=true  
→ 내 개인 일정 포함  

includeMyPersonal=false  
→ 내 개인 일정 제외  


4️⃣ 멀티데이 일정 count 처리 구현

startAt ~ endAt 기간 동안  
해당 날짜 전체에 count 반영하도록 구현


🧪 테스트 결과

✅ 주간 캘린더 count 정상 동작 확인  
멀티데이 일정 → 기간 전체 count 반영 확인  

✅ includeMyPersonal=true  
개인 일정 포함 정상 동작 확인  

✅ includeMyPersonal=false  
개인 일정 제외 정상 동작 확인  

✅ 오늘의 일정 조회 정상 동작 확인  
팀 일정 / 개인 일정 정상 반환  

✅ 팀 스페이스 조회 정상 동작 확인  

✅ 알림 뱃지 조회 정상 동작 확인  
hasUnread=true 정상 반영 확인  


🔍 변경 범위

home 패키지 추가  

- HomeController 구현  
- HomeService / HomeServiceImpl 구현  
- HomeQueryRepository / HomeQueryRepositoryImpl 구현  
- DTO 추가  
  - HomeSummaryResponse
  - WeeklyCalendarDayDto
  - TodaySchedulesDto
  - TeamTodaySchedulesDto
  - PersonalScheduleItemDto
  - MyTeamSpaceDto
  - NotificationBadgeDto

NotificationReceiptRepository 연동  


✅ PR 체크 사항

CI 통과 확인  

conflict 없음  

홈 화면 요약 조회 정상 동작 확인  

주간 캘린더 count 정상 동작 확인  

오늘의 일정 조회 정상 동작 확인  

알림 뱃지 정상 동작 확인  
